### PR TITLE
:bug: fix `elseif` syntax in recipes

### DIFF
--- a/src/recipes/recipes.jl
+++ b/src/recipes/recipes.jl
@@ -5,7 +5,7 @@
       x --> longitudes(layer)
       y --> latitudes(layer)
       z --> layer.grid
-   else if get(plotattributes, :seriestype, :histogram) in [:histogram, :density]
+   elseif get(plotattributes, :seriestype, :histogram) in [:histogram, :density]
       filter(!isnan, layer.grid)
    end
 end


### PR DESCRIPTION
Minor fix needed to make the package work correctly.

Adding the package works as expected with:
```
] add https://github.com/EcoJulia/SimpleSDMLayers.jl#master
```

However, it fails to load correctly and returns: 
```
julia> using SimpleSDMLayers
[ Info: Recompiling stale cache file /home/gdansereau/.julia/compiled/v1.1/SimpleSDMLayers/DPfL7.ji for SimpleSDMLayers [2c645270-77db-11e9-22c3-0f302a89c64c]
ERROR: LoadError: LoadError: syntax: use "elseif" instead of "else if"
Stacktrace:
 [1] include at ./boot.jl:326 [inlined]
 [2] include_relative(::Module, ::String) at ./loading.jl:1038
 [3] include at ./sysimg.jl:29 [inlined]
 [4] include(::String) at /home/gdansereau/.julia/packages/SimpleSDMLayers/JJhvi/src/SimpleSDMLayers.jl:1
 [5] top-level scope at none:0
 [6] include at ./boot.jl:326 [inlined]
 [7] include_relative(::Module, ::String) at ./loading.jl:1038
 [8] include(::Module, ::String) at ./sysimg.jl:29
 [9] top-level scope at none:2
 [10] eval at ./boot.jl:328 [inlined]
 [11] eval(::Expr) at ./client.jl:404
 [12] top-level scope at ./none:3
in expression starting at /home/gdansereau/.julia/packages/SimpleSDMLayers/JJhvi/src/recipes/recipes.jl:8
in expression starting at /home/gdansereau/.julia/packages/SimpleSDMLayers/JJhvi/src/SimpleSDMLayers.jl:27
ERROR: Failed to precompile SimpleSDMLayers [2c645270-77db-11e9-22c3-0f302a89c64c] to /home/gdansereau/.julia/compiled/v1.1/SimpleSDMLayers/DPfL7.ji.
Stacktrace:
 [1] compilecache(::Base.PkgId, ::String) at ./loading.jl:1197
 [2] _require(::Base.PkgId) at ./loading.jl:960
 [3] require(::Base.PkgId) at ./loading.jl:858
 [4] require(::Module, ::Symbol) at ./loading.jl:853
```

Fixing the `elseif` in `src/recipes/recipes.jl` fixed the problem for me. I've tested it using 
```
] add https://github.com/EcoJulia/SimpleSDMLayers.jl#fix-elseif
```