### PR TITLE
Overloads for operations on multiple layers

### DIFF
--- a/docs/src/man/overloads.md
+++ b/docs/src/man/overloads.md
@@ -20,6 +20,7 @@ similar
 Base.sum
 Base.maximum
 Base.minimum
+Base.extrema
 ```
 
 ## From `Broadcast`

--- a/docs/src/man/overloads.md
+++ b/docs/src/man/overloads.md
@@ -21,6 +21,12 @@ Base.sum
 Base.maximum
 Base.minimum
 Base.extrema
+Base.max
+Base.min
+Base.+
+Base.-
+Base.*
+Base./
 ```
 
 ## From `Broadcast`

--- a/src/lib/basics.jl
+++ b/src/lib/basics.jl
@@ -25,7 +25,8 @@ end
 """
     _layers_are_compatible(l1::X, l2::Y) where {X <: SimpleSDMLayer, Y <: SimpleSDMLayer}
 
-This returns
+    Internal function to verify if layers are compatible, i.e. have the same
+    size and bounding coordinates.
 
 """
 function _layers_are_compatible(l1::X, l2::Y) where {X <: SimpleSDMLayer, Y <: SimpleSDMLayer}
@@ -34,4 +35,8 @@ function _layers_are_compatible(l1::X, l2::Y) where {X <: SimpleSDMLayer, Y <: S
     l1.left == l2.left || throw(ArgumentError("The layers have different left coordinates"))
     l1.bottom == l2.bottom || throw(ArgumentError("The layers have different bottom coordinates"))
     l1.right == l2.right || throw(ArgumentError("The layers have different right coordinates"))
+end
+
+function _layers_are_compatible(layers::Array{T}) where {T <: SimpleSDMLayer}
+    all(x -> _layers_are_compatible(x, layers[1]), layers)
 end

--- a/src/lib/generated.jl
+++ b/src/lib/generated.jl
@@ -92,3 +92,12 @@ for fun in (:min, :max)
     end)
 end
 
+for fun in (:mean, :std)
+    eval(quote
+        function $op(layers::Array{T}) where {T <: SimpleSDMLayer}
+            newgrid = $op(map(x -> x.grid, layers))
+            newlayer = SimpleSDMResponse(newgrid, layers[1].left, layers[1].right, layers[1].bottom, layers[1].top)
+            return newlayer
+        end
+    end)
+end

--- a/src/lib/generated.jl
+++ b/src/lib/generated.jl
@@ -2,8 +2,8 @@
 
 ops = Dict(
     :Base => [:sum, :maximum, :minimum, :extrema],
-    :Statistics => [:mean, :median, :std]
-    )
+    :Statistics => [:mean, :median, :std],
+)
 
 for op in ops
     mod = op.first
@@ -14,29 +14,30 @@ for op in ops
     end
     for fun in op.second
         eval(quote
-            import $mod: $fun
+            import ($mod):($fun)
         end)
         for ty in (:SimpleSDMResponse, :SimpleSDMPredictor)
-            eval(quote
-            """
-                $($mod).$($fun)(l::$($ty){T}) where {T <: Number}
+            eval(
+                quote
+                    """
+                        $($mod).$($fun)(l::$($ty){T}) where {T <: Number}
 
-            Applies `$($fun)` (from `$($mod)`) to an object of type `$($ty)`. This function has been
-            automatically generated. Note that this function is only applied to the
-            non-`nothing` elements of the layer, and has no method to work on the `dims`
-            keyword; the grid itself can be extracted with `convert(Matrix, l)`.
-            """
-            function $mod.$fun(l::$ty{T}) where {T <: Number}
-                return $mod.$fun(filter(!isnothing, l.grid))
-            end
-            end)
+                    Applies `$($fun)` (from `$($mod)`) to an object of type `$($ty)`. This function has been
+                    automatically generated. Note that this function is only applied to the
+                    non-`nothing` elements of the layer, and has no method to work on the `dims`
+                    keyword; the grid itself can be extracted with `convert(Matrix, l)`.
+                    """
+                    function $mod.$fun(l::$ty{T}) where {T<:Number}
+                        return $mod.$fun(filter(!isnothing, l.grid))
+                    end
+                end,
+            )
         end
     end
 end
 
-whole = Dict(
-    :Base => [:abs, :sqrt, :log, :log2, :log10, :log1p, :exp, :exp2, :exp10, :expm1]
-)
+whole =
+    Dict(:Base => [:abs, :sqrt, :log, :log2, :log10, :log1p, :exp, :exp2, :exp10, :expm1])
 
 for op in whole
     mod = op.first
@@ -47,20 +48,22 @@ for op in whole
     end
     for fun in op.second
         eval(quote
-            import $mod: $fun
+            import ($mod):($fun)
         end)
         for ty in (:SimpleSDMResponse, :SimpleSDMPredictor)
-            eval(quote
-            """
-                $($mod).$($fun)(l::$($ty){T}) where {T <: Number}
+            eval(
+                quote
+                    """
+                        $($mod).$($fun)(l::$($ty){T}) where {T <: Number}
 
-            Applies `$($fun)` (from `$($mod)`) to every cell within a `$($ty)`, as long as
-            this cell is not `nothing`. This function has been automatically generated.
-            """
-            function $mod.$fun(l::$ty{T}) where {T <: Number}
-                return broadcast($mod.$fun, l)
-            end
-            end)
+                    Applies `$($fun)` (from `$($mod)`) to every cell within a `$($ty)`, as long as
+                    this cell is not `nothing`. This function has been automatically generated.
+                    """
+                    function $mod.$fun(l::$ty{T}) where {T<:Number}
+                        return broadcast($mod.$fun, l)
+                    end
+                end,
+            )
         end
     end
 end
@@ -70,58 +73,63 @@ end
 for fun in (:min, :max, :+, :-, :*, :/)
     mod = :Base
     eval(quote
-            import $mod: $fun
-        end)
-    eval(quote
-        """
-            $($mod).$($fun)(l1::SimpleSDMLayer, l2::SimpleSDMLayer)
-        Applies `$($fun)` (from `$($mod)`) to every pair of cells from
-        two `SimpleSDMLayers` and returns the result as a new `SimpleSDMResponse`
-        layer. Note that `$($fun)` is only applied to the pairs without a
-        `nothing` element, and returns `nothing` for the pairs with one. 
-        This function has been automatically generated.
-        """
-        function $mod.$fun(l1::SimpleSDMLayer, l2::SimpleSDMLayer)
-            SimpleSDMLayers._layers_are_compatible(l1, l2)
-            nl = similar(l1)
-            for i in eachindex(nl.grid)
-                nl.grid[i] = isnothing(l1[i]) || isnothing(l2[i]) ? nothing : $mod.$fun(l1[i], l2[i])
-            end
-            return nl
-        end
+        import ($mod):($fun)
     end)
+    eval(
+        quote
+            """
+                $($mod).$($fun)(l1::SimpleSDMLayer, l2::SimpleSDMLayer)
+            Applies `$($fun)` (from `$($mod)`) to every pair of cells from
+            two `SimpleSDMLayers` and returns the result as a new `SimpleSDMResponse`
+            layer. Note that `$($fun)` is only applied to the pairs without a
+            `nothing` element, and returns `nothing` for the pairs with one.
+            This function has been automatically generated.
+            """
+            function $mod.$fun(l1::SimpleSDMLayer, l2::SimpleSDMLayer)
+                SimpleSDMLayers._layers_are_compatible(l1, l2)
+                nl = similar(l1)
+                for i in eachindex(nl.grid)
+                    nl.grid[i] = isnothing(l1[i]) || isnothing(l2[i]) ? nothing :
+                        $mod.$fun(l1[i], l2[i])
+                end
+                return nl
+            end
+        end,
+    )
 end
 
 for fun in (:mean, :std)
     mod = :Statistics
     eval(quote
-            using $mod
-        end)
-    eval(quote
-    """
-        $($mod).$($fun)(layers::Array{T}) where {T <: SimpleSDMLayer}
-        Applies `$($fun)` (from `$($mod)`) to the elements in corresponding
-        positions from the different layers (similar to
-        `mean(a::Array{Matrix})`) and returns the result as a new
-        `SimpleSDMResponse` layer. Note that `$($fun)` is only applied to the
-        positions  without a `nothing` element and returns `nothing` for the pairs with one. 
-        This function has been automatically generated.
-    """
-        function $mod.$fun(layers::Array{T}) where {T <: SimpleSDMLayer}
-            SimpleSDMLayers._layers_are_compatible(layers)
-            grids = map(x -> x.grid, layers)
-
-            indx_notnothing = findall.(!isnothing, grids)
-            unique!(indx_notnothing)
-            indx_notnothing = reduce(intersect, indx_notnothing)
-            
-            newgrid = Array{Any}(nothing, size(layers[1]))
-            newgrid[indx_notnothing] = $mod.$fun(map(x -> x[indx_notnothing], grids))
-            
-            internal_types = unique(typeof.(newgrid))
-            newgrid = convert(Matrix{Union{internal_types...}}, newgrid)
-            
-            return SimpleSDMResponse(newgrid, layers[1])
-        end
+        using $mod
     end)
+    eval(
+        quote
+            """
+                $($mod).$($fun)(layers::Array{T}) where {T <: SimpleSDMLayer}
+                Applies `$($fun)` (from `$($mod)`) to the elements in corresponding
+                positions from the different layers (similar to
+                `mean(a::Array{Matrix})`) and returns the result as a new
+                `SimpleSDMResponse` layer. Note that `$($fun)` is only applied to the
+                positions  without a `nothing` element and returns `nothing` for the pairs with one.
+                This function has been automatically generated.
+            """
+            function $mod.$fun(layers::Array{T}) where {T<:SimpleSDMLayer}
+                SimpleSDMLayers._layers_are_compatible(layers)
+                grids = map(x -> x.grid, layers)
+
+                indx_notnothing = findall.(!isnothing, grids)
+                unique!(indx_notnothing)
+                indx_notnothing = reduce(intersect, indx_notnothing)
+
+                newgrid = Array{Any}(nothing, size(layers[1]))
+                newgrid[indx_notnothing] = $mod.$fun(map(x -> x[indx_notnothing], grids))
+
+                internal_types = unique(typeof.(newgrid))
+                newgrid = convert(Matrix{Union{internal_types...}}, newgrid)
+
+                return SimpleSDMResponse(newgrid, layers[1])
+            end
+        end,
+    )
 end

--- a/src/lib/generated.jl
+++ b/src/lib/generated.jl
@@ -1,5 +1,5 @@
 ops = Dict(
-    :Base => [:sum, :maximum, :minimum],
+    :Base => [:sum, :maximum, :minimum, :extrema],
     :Statistics => [:mean, :median, :std]
     )
 

--- a/src/lib/generated.jl
+++ b/src/lib/generated.jl
@@ -67,7 +67,7 @@ end
 
 ## Multiple layers overloads
 
-for fun in (:min, :max)
+for fun in (:min, :max, :+, :-, :*, :/)
     mod = :Base
     eval(quote
             import $mod: $fun

--- a/src/lib/generated.jl
+++ b/src/lib/generated.jl
@@ -72,26 +72,23 @@ for fun in (:min, :max)
     eval(quote
             import $mod: $fun
         end)
-    for ty in (:SimpleSDMResponse, :SimpleSDMPredictor)
-        eval(quote
-            """
-                $($mod).$($fun)(l::$($ty){T}) where {T <: Number}
-
-            Applies `$($fun)` (from `$($mod)`) to every pair of cell from
-            two `$($ty)` and returns the result as a new `SimpleSDMResponse`
-            layer. Note that `$($fun)` is only applied to the pairs without a
-            `nothing` element, and returns `nothing` for the pairs with one. 
-            This function has been automatically generated.
-            """
-            function $mod.$fun(l1::$ty{T}, l2::$ty{T}) where {T <: Number}
-                SimpleSDMLayers._layers_are_compatible(l1, l2)
-                nl = similar(l1)
-                for i in eachindex(nl.grid)
-                    nl.grid[i] = any(isnothing.([l1[i], l2[i]])) ? nothing : $mod.$fun(l1[i], l2[i])
-                end
-                return nl
+    eval(quote
+        """
+            $($mod).$($fun)(l1::SimpleSDMLayer, l2::SimpleSDMLayer)
+        Applies `$($fun)` (from `$($mod)`) to every pair of cells from
+        two `SimpleSDMLayers` and returns the result as a new `SimpleSDMResponse`
+        layer. Note that `$($fun)` is only applied to the pairs without a
+        `nothing` element, and returns `nothing` for the pairs with one. 
+        This function has been automatically generated.
+        """
+        function $mod.$fun(l1::SimpleSDMLayer, l2::SimpleSDMLayer)
+            SimpleSDMLayers._layers_are_compatible(l1, l2)
+            nl = similar(l1)
+            for i in eachindex(nl.grid)
+                nl.grid[i] = any(isnothing.([l1[i], l2[i]])) ? nothing : $mod.$fun(l1[i], l2[i])
             end
-        end)
-    end
+            return nl
+        end
+    end)
 end
 

--- a/src/lib/generated.jl
+++ b/src/lib/generated.jl
@@ -115,8 +115,11 @@ for fun in (:mean, :std)
             unique!(indx_notnothing)
             indx_notnothing = reduce(intersect, indx_notnothing)
             
-            newgrid = Array{eltype(layers[1])}(nothing, size(layers[1]))
+            newgrid = Array{Any}(nothing, size(layers[1]))
             newgrid[indx_notnothing] = $mod.$fun(map(x -> x[indx_notnothing], grids))
+            
+            internal_types = unique(typeof.(newgrid))
+            newgrid = convert(Matrix{Union{internal_types...}}, newgrid)
             
             return SimpleSDMResponse(newgrid, layers[1])
         end

--- a/src/lib/generated.jl
+++ b/src/lib/generated.jl
@@ -85,7 +85,7 @@ for fun in (:min, :max)
             SimpleSDMLayers._layers_are_compatible(l1, l2)
             nl = similar(l1)
             for i in eachindex(nl.grid)
-                nl.grid[i] = any(isnothing.([l1[i], l2[i]])) ? nothing : $mod.$fun(l1[i], l2[i])
+                nl.grid[i] = isnothing(l1[i]) || isnothing(l2[i]) ? nothing : $mod.$fun(l1[i], l2[i])
             end
             return nl
         end

--- a/src/lib/generated.jl
+++ b/src/lib/generated.jl
@@ -52,7 +52,7 @@ for op in whole
             """
                 $($mod).$($fun)(l::$($ty){T}) where {T <: Number}
 
-            Applies `$($fun)` (from `$($mod)`) to every cell wihtin a `$($ty)`, as long as
+            Applies `$($fun)` (from `$($mod)`) to every cell within a `$($ty)`, as long as
             this cell is not `nothing`. This function has been automatically generated.
             """
             function $mod.$fun(l::$ty{T}) where {T <: Number}

--- a/src/lib/overloads.jl
+++ b/src/lib/overloads.jl
@@ -269,8 +269,7 @@ function Base.Broadcast.broadcast(f, L::LT) where {LT <: SimpleSDMLayer}
     N.grid[findall(!isnothing, L.grid)] .= fv
 
     internal_types = unique(typeof.(N.grid))
-    N.grid = convert(Matrix{Union{internal_types...}}, N.grid)
 
     RT = LT <: SimpleSDMResponse ? SimpleSDMResponse : SimpleSDMPredictor
-    return RT(N.grid, N)
+    return RT(convert(Matrix{Union{internal_types...}}, N.grid), N)
 end

--- a/test/generated.jl
+++ b/test/generated.jl
@@ -7,6 +7,7 @@ S = SimpleSDMPredictor(M, 0.0, 1.0, 0.0, 1.0)
 
 @test maximum(S) ≤ 1.0
 @test minimum(S) ≥ 0.0
+@test extrema(S) == (minimum(S), maximum(S))
 
 using Statistics
 

--- a/test/generated.jl
+++ b/test/generated.jl
@@ -19,4 +19,11 @@ M = ones(Float64, (5, 10))
 S = SimpleSDMPredictor(M, 0.0, 1.0, 0.0, 1.0)
 @test typeof(sqrt(S)) <: SimpleSDMLayer
 
+S1 = SimpleSDMResponse([-1 0 1 nothing], 0.0, 1.0, 0.0, 1.0)
+S2 = SimpleSDMPredictor([Float32.([-2.0 1.0 1.0])... nothing], 0.0, 1.0, 0.0, 1.0)
+Sx = [S1, S2]
+@test reduce(min, Sx).grid == [-2 0 1 nothing]
+@test mean(Sx).grid == [Float32.([-1.5 0.5 1.0])... nothing]
+@test reduce(+, Sx).grid == [-3 1 2 nothing]
+
 end


### PR DESCRIPTION
Following up on the idea of removing the need to interact with the `grid` field, I suggest some more overloads for functions applied to more than one layer. For example, functions would work directly with `layer1` & `layer2`, instead of `layer1.grid` & `layer2.grid`:
```
julia> layer1 = SimpleSDMResponse([1 2]); layer2 = SimpleSDMResponse([3 4]);
julia> layer1 + layer2
SimpleSDMResponse{Int64}(Union{Nothing, Int64}[4 6], -180.0, 180.0, -90.0, 90.0
```
I started working on this when we used `NaN` for missing values, so the fix was quite easy. It's more complicated with `nothing`, and I'm not always sure of the workarounds I've found, but I guess it makes it even more useful.

### To-do list
- [x] Overload for `extrema()`
- [x] Fix type returned by `broadcast`
- [x] `min()` & `max()`
- [x] `mean()` & `std()`
- [x] Extend `_layers_are_compatible()` for more than two layers
- [x] Math operators `+`, `-`, `*` , `/`
- [x] Add more tests for these new overloads?
- ~~Extend `broadcast!()`?~~
- ~~Examples in documentation?~~
