### PR TITLE
DataFrames.jl integration

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -5,6 +5,7 @@ StatsPlots = "f3b207a7-027a-5e70-b257-86293d7955fd"
 GBIF = "ee291a33-5a6c-5552-a3c8-0f29a1181037"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 
 [compat]
 GBIF = "0.2"

--- a/docs/src/examples/gbif.md
+++ b/docs/src/examples/gbif.md
@@ -69,3 +69,53 @@ scatter!(longitudes(kf_occurrences), latitudes(kf_occurrences), lab="", c=:white
 These extensions of `SimpleSDMLayers` functions to work with the `GBIF` package
 are meant to greatly simplify the expression of more complex pipelines, notably
 for actual species distribution modeling.
+
+## DataFrames support
+
+Note that both `SimpleSDMLayers.jl` and `GBIF.jl` offer an (optional)
+integration with the `DataFrames.jl` package.
+Hence, the example above could also be approached with a `DataFrame`-centered
+workflow.
+
+For example, after getting occurrences through `GBIF.jl`, we can convert them
+to a `DataFrame`:
+
+```@example temp
+using DataFrames
+kf_df = DataFrame(kf_occurrences)
+```
+
+We can then extract the temperature values for all the occurrences:
+
+```@example temp
+temperature[kf_df]
+```
+
+Or we can clip the layers according to the occurrences:
+
+```@example temp
+clip(temperature, kf_df)
+```
+
+We can also export all the values from a layer to a `DataFrame` with their
+corresponding coordinates: 
+
+```@example temp
+temperature_df = DataFrame(temperature_clip)
+```
+
+Or do so with multiple layers at the same time:
+
+```@example temp
+climate_clip = [temperature_clip, precipitation_clip]
+climate_df = DataFrame(climate_clip)
+rename!(climate_df, :x1 => :temperature, :x2 => :precipitation)
+```
+
+We can finally plot the values in a similar way:
+
+```@example temp
+filter!(x -> !isnothing(x.temperature) && !isnothing(x.precipitation), climate_df)
+histogram2d(climate_df.temperature, climate_df.precipitation, c=:viridis)
+scatter!(temperature_clip[kf_df], precipitation_clip[kf_occurrences], lab="", c=:white, msc=:orange)
+```

--- a/src/SimpleSDMLayers.jl
+++ b/src/SimpleSDMLayers.jl
@@ -52,6 +52,11 @@ function __init__()
         @info "GBIF integration loaded"
         include(joinpath(dirname(pathof(SimpleSDMLayers)), "integrations", "GBIF.jl"))
     end
+    @require DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0" begin
+        @info "DataFrames integration loaded"
+        include(joinpath(dirname(pathof(SimpleSDMLayers)), "integrations", "DataFrames.jl"))
+    end
+
 end
 
 end # module

--- a/src/integrations/DataFrames.jl
+++ b/src/integrations/DataFrames.jl
@@ -72,8 +72,9 @@ function DataFrames.DataFrame(layers::Array{T}; kw...) where {T <: SimpleSDMLaye
     lons = repeat(longitudes(l1), inner = size(l1, 1))
     values = mapreduce(x -> vec(x.grid), hcat, layers)
     
-    df = DataFrames.DataFrame(hcat(lats, lons, values); kw...)
-    DataFrames.rename!(df, [:latitude, :longitude, Symbol.("x", eachindex(layers))...])
+    df = DataFrames.DataFrame(values; kw...)
+    insertcols!(df, 1, :latitude => lats)
+    insertcols!(df, 1, :longitude => lons)
     return df
 end
 

--- a/src/integrations/DataFrames.jl
+++ b/src/integrations/DataFrames.jl
@@ -15,4 +15,33 @@ function Base.getindex(layer::T, df::DataFrames.DataFrame; latitude = :latitude,
     lons = df[:, longitude]
     return [layer[lon, lat] for (lon, lat) in zip(lons, lats)]
 end
+
+"""
+    clip(p::T, r::DataFrames.DataFrame)
+
+Returns a clipped version (with a 10% margin) around all occurences in a
+`DataFrame`.
+"""
+function SimpleSDMLayers.clip(layer::T, df::DataFrames.DataFrame; latitude = :latitude, longitude = :longitude) where {T <: SimpleSDMLayer}
+   occ_latitudes = filter(!ismissing, df[:, latitude])
+   occ_longitudes = filter(!ismissing, df[:, longitude])
+
+   lat_min = minimum(occ_latitudes)
+   lat_max = maximum(occ_latitudes)
+   lon_min = minimum(occ_longitudes)
+   lon_max = maximum(occ_longitudes)
+
+   lat_Δ = abs(lat_max - lat_min)
+   lon_Δ = abs(lon_max - lon_min)
+
+   scaling = 0.1
+   lon_s = scaling*lon_Δ
+   lat_s = scaling*lat_Δ
+
+   lat_max = min(layer.top, lat_max+lat_s)
+   lat_min = max(layer.bottom, lat_min-lat_s)
+   lon_max = min(layer.right, lon_max+lon_s)
+   lon_min = max(layer.left, lon_min-lon_s)
+
+   return layer[left=lon_min, right=lon_max, bottom=lat_min, top=lat_max]
 end

--- a/src/integrations/DataFrames.jl
+++ b/src/integrations/DataFrames.jl
@@ -1,2 +1,17 @@
 # WARNING this file is only loaded if DataFrames.jl is also active
 # This all happens thanks to the Requires.jl package
+
+import Base: getindex
+import Base: setindex!
+import SimpleSDMLayers: clip, latitudes, longitudes
+
+"""
+    Base.getindex(p::T, r::GBIF.GBIFRecords) where {T <: SimpleSDMLayer}
+
+Returns the values of a layer at all occurrences in a `DataFrame`.
+"""
+function Base.getindex(l::T, df::DataFrames.DataFrame; latitude = :latitude, longitude = :longitude) where {T <: SimpleSDMLayer}
+    lats = df[:, latitude]
+    lons = df[:, longitude]
+    return [l[lon, lat] for (lon, lat) in zip(lons, lats)]
+end

--- a/src/integrations/DataFrames.jl
+++ b/src/integrations/DataFrames.jl
@@ -15,3 +15,15 @@ function Base.getindex(l::T, df::DataFrames.DataFrame; latitude = :latitude, lon
     lons = df[:, longitude]
     return [l[lon, lat] for (lon, lat) in zip(lons, lats)]
 end
+
+"""
+    Base.setindex!(p::T, v, occurrence::GBIFRecord) where {T <: SimpleSDMResponse}
+
+Changes the values of the cell including the point at the requested latitude and
+longitude.
+"""
+function Base.setindex!(l::SimpleSDMResponse{T}, values::Array{T}, df::DataFrames.DataFrame; latitude = :latitude, longitude = :longitude) where {T}
+    lats = df[:, latitude]
+    lons = df[:, longitude]
+    [setindex!(l, v, lon, lat) for (v, lon, lat) in zip(values, lons, lats)]
+end

--- a/src/integrations/DataFrames.jl
+++ b/src/integrations/DataFrames.jl
@@ -10,8 +10,9 @@ import SimpleSDMLayers: clip, latitudes, longitudes
 
 Returns the values of a layer at all occurrences in a `DataFrame`.
 """
-function Base.getindex(l::T, df::DataFrames.DataFrame; latitude = :latitude, longitude = :longitude) where {T <: SimpleSDMLayer}
+function Base.getindex(layer::T, df::DataFrames.DataFrame; latitude = :latitude, longitude = :longitude) where {T <: SimpleSDMLayer}
     lats = df[:, latitude]
     lons = df[:, longitude]
-    return [l[lon, lat] for (lon, lat) in zip(lons, lats)]
+    return [layer[lon, lat] for (lon, lat) in zip(lons, lats)]
+end
 end

--- a/src/integrations/DataFrames.jl
+++ b/src/integrations/DataFrames.jl
@@ -55,7 +55,7 @@ longitudes and grid values.
 function DataFrames.DataFrame(layer::T; kw...) where {T <: SimpleSDMLayer}
     lats = repeat(latitudes(layer), outer = size(layer, 2))
     lons = repeat(longitudes(layer), inner = size(layer, 1))
-    return DataFrames.DataFrame(latitude = lats, longitudes = lons, values = vec(layer.grid); kw...)
+    return DataFrames.DataFrame(latitude = lats, longitude = lons, values = vec(layer.grid); kw...)
 end
 
 """

--- a/src/integrations/DataFrames.jl
+++ b/src/integrations/DataFrames.jl
@@ -89,12 +89,16 @@ function SimpleSDMResponse(df::DataFrames.DataFrame, col::Symbol, layer::SimpleS
     uniquelats = unique(lats)
     uniquelons = unique(lons)
 
-    lats_idx = [SimpleSDMLayers._match_latitude(layer, lat) for lat in lats]
-    lons_idx = [SimpleSDMLayers._match_longitude(layer, lon) for lon in lons]
-
     grid = Array{Any}(nothing, size(layer))
-    for (lat, lon, value) in zip(lats_idx, lons_idx, df[:, col])
-        grid[lat, lon] = value
+
+    if uniquelats == latitudes(layer) && uniquelons == longitudes(layer)
+        grid[:] = df[:, col]
+    else
+        lats_idx = [SimpleSDMLayers._match_latitude(layer, lat) for lat in lats]
+        lons_idx = [SimpleSDMLayers._match_longitude(layer, lon) for lon in lons]
+        for (lat, lon, value) in zip(lats_idx, lons_idx, df[:, col])
+            grid[lat, lon] = value
+        end
     end
 
     internal_types = unique(typeof.(grid))

--- a/src/integrations/DataFrames.jl
+++ b/src/integrations/DataFrames.jl
@@ -1,0 +1,2 @@
+# WARNING this file is only loaded if DataFrames.jl is also active
+# This all happens thanks to the Requires.jl package

--- a/src/integrations/DataFrames.jl
+++ b/src/integrations/DataFrames.jl
@@ -15,15 +15,3 @@ function Base.getindex(l::T, df::DataFrames.DataFrame; latitude = :latitude, lon
     lons = df[:, longitude]
     return [l[lon, lat] for (lon, lat) in zip(lons, lats)]
 end
-
-"""
-    Base.setindex!(p::T, v, occurrence::GBIFRecord) where {T <: SimpleSDMResponse}
-
-Changes the values of the cell including the point at the requested latitude and
-longitude.
-"""
-function Base.setindex!(l::SimpleSDMResponse{T}, values::Array{T}, df::DataFrames.DataFrame; latitude = :latitude, longitude = :longitude) where {T}
-    lats = df[:, latitude]
-    lons = df[:, longitude]
-    [setindex!(l, v, lon, lat) for (v, lon, lat) in zip(values, lons, lats)]
-end

--- a/src/integrations/DataFrames.jl
+++ b/src/integrations/DataFrames.jl
@@ -73,8 +73,8 @@ function DataFrames.DataFrame(layers::Array{T}; kw...) where {T <: SimpleSDMLaye
     values = mapreduce(x -> vec(x.grid), hcat, layers)
     
     df = DataFrames.DataFrame(values; kw...)
-    insertcols!(df, 1, :latitude => lats)
-    insertcols!(df, 1, :longitude => lons)
+    DataFrames.insertcols!(df, 1, :latitude => lats)
+    DataFrames.insertcols!(df, 1, :longitude => lons)
     return df
 end
 

--- a/src/integrations/DataFrames.jl
+++ b/src/integrations/DataFrames.jl
@@ -6,7 +6,7 @@ import Base: setindex!
 import SimpleSDMLayers: clip, latitudes, longitudes
 
 """
-    Base.getindex(p::T, r::GBIF.GBIFRecords) where {T <: SimpleSDMLayer}
+    Base.getindex(layer::T, df::DataFrames.DataFrame; latitude = :latitude, longitude = :longitude) where {T <: SimpleSDMLayer}
 
 Returns the values of a layer at all occurrences in a `DataFrame`.
 """
@@ -17,7 +17,7 @@ function Base.getindex(layer::T, df::DataFrames.DataFrame; latitude = :latitude,
 end
 
 """
-    clip(p::T, r::DataFrames.DataFrame)
+    function clip(layer::T, df::DataFrames.DataFrame; latitude = :latitude, longitude = :longitude) where {T <: SimpleSDMLayer}
 
 Returns a clipped version (with a 10% margin) around all occurences in a
 `DataFrame`.

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -3,6 +3,7 @@ Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 GBIF = "ee291a33-5a6c-5552-a3c8-0f29a1181037"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 
 [compat]
 GBIF = "0.2"

--- a/test/dataframes.jl
+++ b/test/dataframes.jl
@@ -1,0 +1,24 @@
+module SSLTestDataFrames
+using SimpleSDMLayers
+using DataFrames
+using Test
+
+temperature = worldclim(1)
+
+df = DataFrame(latitude = [0.0, 1.0], longitude = [30.0, 31.0], values = [42.0, 15.0])
+
+@test eltype(temperature[df]) <: Number
+
+temperature_clip = clip(temperature, df)
+
+@test typeof(temperature_clip) == typeof(temperature)
+
+@test typeof(DataFrame(temperature_clip)) == DataFrame
+@test eltype(DataFrame(temperature_clip).values) == eltype(temperature_clip.grid)
+@test typeof(DataFrame([temperature_clip, temperature_clip])) == DataFrame
+@test eltype(DataFrame([temperature_clip, temperature_clip]).x1) == eltype(temperature_clip.grid)
+
+@test typeof(SimpleSDMPredictor(df, :values, temperature_clip)) <: SimpleSDMLayer
+@test typeof(SimpleSDMPredictor(df, :values, temperature_clip)) <: SimpleSDMPredictor
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,7 @@ tests = [
    "coarsen" => "coarsen.jl",
    "plotting" => "plots.jl",
    "GBIF" => "gbif.jl"
+   "DataFrames" => "dataframes.jl"
 ]
 
 for test in tests

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,7 +14,7 @@ tests = [
    "chelsa" => "chelsa.jl",
    "coarsen" => "coarsen.jl",
    "plotting" => "plots.jl",
-   "GBIF" => "gbif.jl"
+   "GBIF" => "gbif.jl",
    "DataFrames" => "dataframes.jl"
 ]
 


### PR DESCRIPTION
closes #28 

### To-do
- [x] `getindex()`
- [x] ~~`setindex()`~~ --> Don't think it's really needed
- [x] `clip()`
- [x] ~~`latitudes()` & `longitudes()`~~ --> not really needed, it's just `filter(!isnothing, df.latitude)`
- [x] Layer to DataFrame : `convert()` or `DataFrame()`
  - Make lat-lon columns optional?
  - Option to directly filter cells with `nothing`?
- [x] DataFrame to Layer: 
  - [x] `SimpleSDMResponse`
  - [x] `SimpleSDMPredictor`?
  - Better way to make fast & efficient?
  - Method that doesn't require a layer?
- [ ] Upload `presenceabsence()` function?
- [x] Add tests
- [x] Add documentation & examples