### PR TITLE
Fix CHELSA URL root

### DIFF
--- a/src/datasets/download_layer.jl
+++ b/src/datasets/download_layer.jl
@@ -56,7 +56,7 @@ function download_layer(::BioClim, layer::Integer)
     path = SimpleSDMLayers.assets_path()
     layer = lpad(layer, 2, "0")
     filename = "CHELSA_bio10_$(layer).tif"
-    url_root = "ftp://envidatrepo.wsl.ch/uploads/chelsa/chelsa_V1/bioclim/integer/"
+    url_root = "ftp://envidatrepo.wsl.ch/uploads/chelsa/chelsa_V1/climatologies/bio/"
 
     filepath = joinpath(path, filename)
     if !(isfile(filepath))


### PR DESCRIPTION
The CHELSA test keeps failing recently. I think it's because there's been a change in the file organization of the CHELSA server. 
`ftp://envidatrepo.wsl.ch/uploads/chelsa/chelsa_V1/bioclim/integer/` should now be `ftp://envidatrepo.wsl.ch/uploads/chelsa/chelsa_V1/climatologies/bio/`. Is this the right data?