### PR TITLE
Compatibility with GBIF v0.3

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,19 +10,25 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
         version:
           - '1.3'
           - '1.4'
           - '1.5'
-          - 'nightly'
         os:
           - ubuntu-latest
           - macOS-latest
           - windows-latest
         arch:
           - x64
+        experimental: [false]
+        include:
+          - version: nightly
+          - os: [ubuntu-latest, macOS-latest, windows-latest]
+          - arch: x64
+          - experimental: true
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,11 +24,6 @@ jobs:
         arch:
           - x64
         experimental: [false]
-        include:
-          - version: 'nightly'
-            os: ubuntu-latest
-            arch: x64
-            experimental: true
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,10 +25,10 @@ jobs:
           - x64
         experimental: [false]
         include:
-          - version: 'nightly'
+          - version: ['nightly']
             os: [ubuntu-latest, macOS-latest, windows-latest]
-            arch: x64
-            experimental: true
+            arch: [x64]
+            experimental: [true]
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,10 +25,10 @@ jobs:
           - x64
         experimental: [false]
         include:
-          - version: nightly
-          - os: [ubuntu-latest, macOS-latest, windows-latest]
-          - arch: x64
-          - experimental: true
+          - version: 'nightly'
+            os: [ubuntu-latest, macOS-latest, windows-latest]
+            arch: x64
+            experimental: true
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,6 +15,7 @@ jobs:
         version:
           - '1.3'
           - '1.4'
+          - '1.5'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,10 +25,10 @@ jobs:
           - x64
         experimental: [false]
         include:
-          - version: ['nightly']
-            os: [ubuntu-latest, macOS-latest, windows-latest]
-            arch: [x64]
-            experimental: [true]
+          - version: 'nightly'
+            os: ubuntu-latest
+            arch: x64
+            experimental: true
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -8,4 +8,4 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 
 [compat]
-GBIF = "0.2"
+GBIF = "0.2, 0.3"

--- a/docs/src/examples/gbif.md
+++ b/docs/src/examples/gbif.md
@@ -56,6 +56,9 @@ scatter!(temperature_clip[kf_occurrences], precipitation_clip[kf_occurrences], l
 This will return a record of all data for all geo-localized occurrences (*i.e.*
 neither the latitude nor the longitude is `missing`) in a `GBIFRecords`
 collection, as an array of the `eltype` of the layer.
+Note that the layer values can be `nothing`, in which case you might need to
+run `filter(!isnothing, temperature_clip[kf_occurrences]` for it to work with 
+the plotting functions.
 
 We can also plot the records over space, using the overloads of the `latitudes`
 and `longitudes` functions:
@@ -119,5 +122,5 @@ We can finally plot the values in a similar way:
 ```@example temp
 filter!(x -> !isnothing(x.temperature) && !isnothing(x.precipitation), climate_df);
 histogram2d(climate_df.temperature, climate_df.precipitation, c=:viridis)
-scatter!(temperature_clip[kf_df], precipitation_clip[kf_occurrences], lab="", c=:white, msc=:orange)
+scatter!(temperature_clip[kf_df], precipitation_clip[kf_df], lab="", c=:white, msc=:orange)
 ```

--- a/docs/src/examples/gbif.md
+++ b/docs/src/examples/gbif.md
@@ -18,14 +18,13 @@ We can get some occurrences for the taxon of interest:
 
 ```@example temp
 kingfisher = GBIF.taxon("Megaceryle alcyon", strict=true)
-kf_occurrences = occurrences(kingfisher)
+kf_occurrences = occurrences(kingfisher, "hasCoordinate" => "true")
 
 # We will get some more occurrences
 for i in 1:9
   occurrences!(kf_occurrences)
 end
 
-filter!(GBIF.have_ok_coordinates, kf_occurrences)
 @info kf_occurrences
 ```
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,9 +1,9 @@
 [deps]
-Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-GBIF = "ee291a33-5a6c-5552-a3c8-0f29a1181037"
-Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+GBIF = "ee291a33-5a6c-5552-a3c8-0f29a1181037"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-GBIF = "0.2"
+GBIF = "0.2, 0.3"

--- a/test/gbif.jl
+++ b/test/gbif.jl
@@ -7,8 +7,7 @@ temperature = worldclim(1)
 
 kingfisher = GBIF.taxon("Megaceryle alcyon", strict=true)
 
-o = GBIF.occurrences(kingfisher)
-filter!(GBIF.have_ok_coordinates, o)
+o = GBIF.occurrences(kingfisher, "hasCoordinate" => "true")
 
 # Extract from a single record
 for oc in o


### PR DESCRIPTION
@tpoisot As you mentioned in EcoJulia/GBIF.jl#36, GBIF v0.3 did break a few things here, but only the GBIF example and test (because they used the filtering functions). The rest of the integration works fine from what I've tested.

I've fixed them both -- they should work with either GBIF v0.3 or v0.2.
(Or should we just remove the compat for 0.2?)