### PR TITLE
Fix bug in `geotiff()` with layers coordinates & stride

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SimpleSDMLayers"
 uuid = "2c645270-77db-11e9-22c3-0f302a89c64c"
 authors = ["Timothée Poisot <timothee.poisot@umontreal.ca>"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 ArchGDAL = "c9ce4bd3-c3d5-55b8-8973-c0e20141b8c3"

--- a/src/datasets/geotiff.jl
+++ b/src/datasets/geotiff.jl
@@ -73,6 +73,6 @@ function geotiff(
     buffer = convert(Matrix{Union{Nothing,eltype(buffer)}}, rotl90(buffer))
     buffer[findall(buffer .== minimum(buffer))] .= nothing
 
-    return LT(buffer, left_pos-0.5lon_stride, right_pos+0.5lon_stride, bottom_pos+0.5lat_stride, top_pos-0.5lat_stride)
+    return LT(buffer, left_pos-0.5lon_stride, right_pos+0.5lon_stride, bottom_pos-0.5lat_stride, top_pos+0.5lat_stride)
 
 end


### PR DESCRIPTION
@tpoisot I found this bug in the `geotiff()` function, which was causing problems in one of my scripts. Can you confirm the signs weren't inverted on purpose in the `return` call?

As you can see below, `geotiff()` returned wrong bounding latitudes in functions such as `worldclim()` (I would expect them to be `90.0`, not `89.83`). In turn it messed up with `stride()` and `latitudes()`.

```bash
julia> wc = worldclim(1);
julia> wc.left, wc.right, wc.bottom, wc.top
(-180.0, 180.0, -89.83333333333334, 89.83333333333334)
julia> stride(wc)
(0.08333333333333333, 0.08317901234567902)
julia> longitudes(wc)
-179.91666666666666:0.16666666666666666:179.91666666666666
julia> latitudes(wc)
-89.75015432098766:0.16635802469135805:89.75015432098766
```

With the small change, it now looks fine:
```bash
julia> wc = worldclim(1);
julia> wc.left, wc.right, wc.bottom, wc.top
(-180.0, 180.0, -90.0, 90.0)
julia> stride(wc)
(0.08333333333333333, 0.08333333333333333)
julia> longitudes(wc)
-179.91666666666666:0.16666666666666666:179.91666666666666
julia> latitudes(wc)
-89.91666666666667:0.16666666666666666:89.91666666666667
```


