### PR TITLE
Fix CHELSA download url

### DIFF
--- a/src/datasets/download_layer.jl
+++ b/src/datasets/download_layer.jl
@@ -56,7 +56,7 @@ function download_layer(::BioClim, layer::Integer)
     path = SimpleSDMLayers.assets_path()
     layer = lpad(layer, 2, "0")
     filename = "CHELSA_bio10_$(layer).tif"
-    url_root = "ftp://envidatrepo.wsl.ch/uploads/chelsa/chelsa_V1/climatologies/bio/"
+    url_root = "ftp://envicloud.wsl.ch/chelsa/chelsa_V1/climatologies/bio/"
 
     filepath = joinpath(path, filename)
     if !(isfile(filepath))

--- a/src/datasets/download_layer.jl
+++ b/src/datasets/download_layer.jl
@@ -56,7 +56,7 @@ function download_layer(::BioClim, layer::Integer)
     path = SimpleSDMLayers.assets_path()
     layer = lpad(layer, 2, "0")
     filename = "CHELSA_bio10_$(layer).tif"
-    url_root = "ftp://envicloud.wsl.ch/chelsa/chelsa_V1/climatologies/bio/"
+    url_root = "https://envicloud.os.zhdk.cloud.switch.ch/chelsa/chelsa_V1/climatologies/bio/"
 
     filepath = joinpath(path, filename)
     if !(isfile(filepath))


### PR DESCRIPTION
**What the pull request does**   

Previous tests are failed in the `test/chelsa.jl` script with:
```julia
julia> lc1 = bioclim(1; left=-5.0, right=7.0, bottom=30.0, top=45.0)
ERROR: DNSError: envidatrepo.wsl.ch, unknown node or service (EAI_NONAME)
```

I believe it's because the URL of the CHELSA FTP server has changed from `ftp://envidatrepo.wsl.ch` to `ftp://envicloud.wsl.ch` (That's the link on the CHELSA website).
Hopefully this should fix it.

**Type of change**   

Please indicate the relevant option(s)

- [x] :bug: Bug fix (non-breaking change which fixes an issue)
- [ ] :sparkle: New feature (non-breaking change which adds functionality)
- [ ] :boom: Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] :book: This change requires a documentation update

**Checklist**

- [x] The changes are documented
  - [x] The docstrings of the different functions describe the arguments, purpose, and behavior 
  - [x] There are examples in the documentation website
- [x] The changes are tested
- [x] The changes **do not** modify the behavior of the previously existing functions
  - If they **do**, please explain why and how in the introduction paragraph
- [x] For **new contributors** - my name and information are added to `.zenodo.json`
- [ ] The `Project.toml` field `version` has been updated
  - Change the *last* number for a `v0.0.x` series release, a bug fix, or a performance improvement
  - Change the *middle* number for additional features that *do not* break the current test suite (unless you fix a bug in the test suite)
  - Change the *first* number for changes that break the current test suite
