### PR TITLE
✨ add latitudes for single GBIF record

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SimpleSDMLayers"
 uuid = "2c645270-77db-11e9-22c3-0f302a89c64c"
 authors = ["Timothée Poisot <timothee.poisot@umontreal.ca>", "Gabriel Dansereau <gabriel.dansereau@umontreal.ca>"]
-version = "0.4.3"
+version = "0.4.4"
 
 [deps]
 ArchGDAL = "c9ce4bd3-c3d5-55b8-8973-c0e20141b8c3"

--- a/src/integrations/GBIF.jl
+++ b/src/integrations/GBIF.jl
@@ -68,20 +68,20 @@ function Base.getindex(layer::T, records::GBIF.GBIFRecords) where {T <: SimpleSD
    return convert(Vector{SimpleSDMLayers._inner_type(layer)}, filter(!isnothing, [layer[records[i]] for i in 1:length(records)]))
 end
 
+SimpleSDMLayers.longitudes(record::GBIF.GBIFRecord) = record.longitude
+SimpleSDMLayers.latitudes(record::GBIF.GBIFRecord) = record.latitude
+
 """
     latitudes(records::GBIFRecords)
 
 Returns the non-missing latitudes.
 """
-function SimpleSDMLayers.latitudes(records::GBIF.GBIFRecords)
-   return filter(!ismissing, [records[i].latitude for i in 1:length(records)])
-end
+SimpleSDMLayers.latitudes(records::GBIF.GBIFRecords) = filter(!ismissing, [latitudes(record) for i in 1:length(records)])
 
 """
     longitudes(records::GBIFRecords)
 
 Returns the non-missing longitudes.
 """
-function SimpleSDMLayers.longitudes(records::GBIF.GBIFRecords)
-   return filter(!ismissing, [records[i].longitude for i in 1:length(records)])
-end
+SimpleSDMLayers.longitudes(records::GBIF.GBIFRecords) = filter(!ismissing, [longitudes(record) for i in 1:length(records)])
+


### PR DESCRIPTION
**What the pull request does**   

Closes #62  by adding a `latitudes` and `longitudes` method for `GBIFRecord` -- this is used internally by the `latitudes` and `longitudes` methods for `GBIFRecords`.