### PR TITLE
Mask a layer by GBIF occurrences

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SimpleSDMLayers"
 uuid = "2c645270-77db-11e9-22c3-0f302a89c64c"
 authors = ["Timothée Poisot <timothee.poisot@umontreal.ca>", "Gabriel Dansereau <gabriel.dansereau@umontreal.ca>"]
-version = "0.4.4"
+version = "0.4.5"
 
 [deps]
 ArchGDAL = "c9ce4bd3-c3d5-55b8-8973-c0e20141b8c3"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -14,7 +14,6 @@ makedocs(
             "Overloads" => "man/overloads.md",
             "Other operations" => "man/operations.md",
             "Data" => "man/data.md",
-            "Plotting" => "man/plotting.md"
         ],
         "Examples" => [
             "Temperature data" => "examples/temperature.md",

--- a/docs/src/examples/gbif.md
+++ b/docs/src/examples/gbif.md
@@ -72,55 +72,23 @@ These extensions of `SimpleSDMLayers` functions to work with the `GBIF` package
 are meant to greatly simplify the expression of more complex pipelines, notably
 for actual species distribution modeling.
 
-## DataFrames support
-
-Note that both `SimpleSDMLayers.jl` and `GBIF.jl` offer an (optional)
-integration with the `DataFrames.jl` package.
-Hence, the example above could also be approached with a `DataFrame`-centered
-workflow.
-
-For example, after getting occurrences through `GBIF.jl`, we can convert them
-to a `DataFrame`:
-
 ```@example temp
-using DataFrames
-kf_df = DataFrame(kf_occurrences);
-last(kf_df, 5)
+contour(precipitation_clip, c=:YlGnBu, title="Precipitation", frame=:box, fill=true)
+scatter!(longitudes(kf_occurrences), latitudes(kf_occurrences), lab="", c=:white, msc=:orange)
 ```
 
-We can then extract the temperature values for all the occurrences:
+We can finally make a presence/absence map:
 
 ```@example temp
-temperature[kf_df]
+presabs = mask(precipitation_clip, kf_occurrences)
+plot(presabs)
 ```
 
-Or we can clip the layers according to the occurrences:
+This can be useful if we want to add a buffer around the observations - for
+example, we can add a 50km buffer around all observations:
 
 ```@example temp
-clip(temperature, kf_df)
+buffered = slidingwindow(presabs, maximum, 50.0)
+plot(buffered)
 ```
 
-We can also export all the values from a layer to a `DataFrame` with their
-corresponding coordinates: 
-
-```@example temp
-temperature_df = DataFrame(temperature_clip);
-last(temperature_df, 5)
-```
-
-Or do so with multiple layers at the same time:
-
-```@example temp
-climate_clip = [temperature_clip, precipitation_clip]
-climate_df = DataFrame(climate_clip);
-rename!(climate_df, :x1 => :temperature, :x2 => :precipitation);
-last(climate_df, 5)
-```
-
-We can finally plot the values in a similar way:
-
-```@example temp
-filter!(x -> !isnothing(x.temperature) && !isnothing(x.precipitation), climate_df);
-histogram2d(climate_df.temperature, climate_df.precipitation, c=:viridis)
-scatter!(temperature_clip[kf_df], precipitation_clip[kf_df], lab="", c=:white, msc=:orange)
-```

--- a/docs/src/man/plotting.md
+++ b/docs/src/man/plotting.md
@@ -1,7 +1,0 @@
-# Plotting
-
-Plotting currently supports (through Plots and StatsPlots) `heatmap` and
-`contour` (for the values of a single layer), `density` and `histogram` (for the
-non-`NaN` values), as well as `scatter` and `histogram2d` for two layers. All
-usual options for plots apply. There are numerous illustrations of the plotting
-functions in the examples.

--- a/src/integrations/GBIF.jl
+++ b/src/integrations/GBIF.jl
@@ -89,33 +89,31 @@ end
 """
     mask!(layer::SimpleSDMResponse{T}, records::GBIF.GBIFRecords) where {T <: AbstractBool}
 
-Changes the second layer so that the positions for which the first layer is zero
-(of the appropriate type) or `nothing` are set to `nothing`. This is mostly
-useful in cases where you have a `Bool` layer.
+Fills a layer (most likely created with `similar`) so that the values are `true`
+if an occurrence is found in the cell, `false` if not.
 """
-function mask!(layer::SimpleSDMResponse{T}, records::GBIF.GBIFRecords) where {T1 <: AbstractBool}
+function mask!(layer::SimpleSDMResponse{T}, records::GBIF.GBIFRecords) where {T <: Bool}
     layer[records] .= true
     return layer
 end
 
 """
-    mask!(layer::SimpleSDMResponse{T}, records::GBIF.GBIFRecords) where {T <: AbstractBool}
+    mask!(layer::SimpleSDMResponse{T}, records::GBIF.GBIFRecords) where {T <: Number}
 
-Changes the second layer so that the positions for which the first layer is zero
-(of the appropriate type) or `nothing` are set to `nothing`. This is mostly
-useful in cases where you have a `Bool` layer.
+Fills a layer (most likely created with `similar`) so that the values reflect
+the number of occurrences in the cell.
 """
-function mask!(layer::SimpleSDMResponse{T}, records::GBIF.GBIFRecords) where {T1 <: Number}
-    layer[records] .+= convert(eltype(layer), 1)
+function mask!(layer::SimpleSDMResponse{T}, records::GBIF.GBIFRecords) where {T <: Number}
+    layer[records] .+= one(T)
     return layer
 end
 
 """
-    mask(l1::T1, l2::T2) where {T1 <: SimpleSDMLayer, T2 <: SimpleSDMLayer}
+    mask(layer::SimpleSDMLayer, records::GBIF.GBIFRecords, element_type::Type=Bool)
 
-Returns a copy of the second layer in which the positions for which the first
-layer is zero (of the appropriate type) or `nothing` are set to `nothing`. This
-is mostly useful in cases where you have a `Bool` layer.
+Create a new layer storing information about the presence of occurrences in the
+cells, either counting (numeric types) or presence-absence-ing (boolean types)
+them.
 """
 function mask(layer::SimpleSDMLayer, records::GBIF.GBIFRecords, element_type::Type=Bool)
     returnlayer = similar(layer, element_type)

--- a/src/integrations/GBIF.jl
+++ b/src/integrations/GBIF.jl
@@ -30,6 +30,17 @@ function Base.setindex!(p::SimpleSDMResponse{T}, v::T, occurrence::GBIF.GBIFReco
 end
 
 """
+    Base.setindex!(p::T, v, records::GBIFRecords) where {T <: SimpleSDMResponse}
+
+Changes the values of the cell including the point for all the records.
+"""
+function Base.setindex!(p::SimpleSDMResponse{T}, v::T, records::GBIF.GBIFRecords) where {T}
+   ismissing(occurrence.latitude) && return nothing
+   ismissing(occurrence.longitude) && return nothing
+   setindex!(p, v, occurrence.longitude, occurrence.latitude)
+end
+
+"""
     clip(p::T, r::GBIF.GBIFRecords)
 
 Returns a clipped version (with a 10% margin) around all occurences in a

--- a/src/integrations/GBIF.jl
+++ b/src/integrations/GBIF.jl
@@ -11,24 +11,24 @@ import SimpleSDMLayers: clip, latitudes, longitudes, mask!, mask
 Extracts the value of a layer at a given position for a `GBIFRecord`. If the
 `GBIFRecord` has no latitude or longitude, this will return `nothing`.
 """
-function Base.getindex(layer::T, occurrence::GBIF.GBIFRecord) where {T <: SimpleSDMLayer}
-   ismissing(occurrence.latitude) && return nothing
-   ismissing(occurrence.longitude) && return nothing
-   return layer[occurrence.longitude, occurrence.latitude]
+function Base.getindex(layer::T, record::GBIF.GBIFRecord) where {T <: SimpleSDMLayer}
+   ismissing(record.latitude) && return nothing
+   ismissing(record.longitude) && return nothing
+   return layer[record.longitude, record.latitude]
 end
 
 """
-    Base.setindex!(p::T, v, occurrence::GBIFRecord) where {T <: SimpleSDMResponse}
+    Base.setindex!(p::T, v, record::GBIFRecord) where {T <: SimpleSDMResponse}
 
 Changes the values of the cell including the point at the requested latitude and
 longitude. **Be careful**, this function will not update a cell that has
 `nothing`.
 """
-function Base.setindex!(layer::SimpleSDMResponse{T}, v::T, occurrence::GBIF.GBIFRecord) where {T}
-   ismissing(occurrence.latitude) && return nothing
-   ismissing(occurrence.longitude) && return nothing
+function Base.setindex!(layer::SimpleSDMResponse{T}, v::T, record::GBIF.GBIFRecord) where {T}
+   ismissing(record.latitude) && return nothing
+   ismissing(record.longitude) && return nothing
    isnothing(layer[record]) && return nothing
-   setindex!(layer, v, occurrence.longitude, occurrence.latitude)
+   setindex!(layer, v, record.longitude, record.latitude)
 end
 
 """

--- a/src/integrations/GBIF.jl
+++ b/src/integrations/GBIF.jl
@@ -18,7 +18,7 @@ function Base.getindex(layer::T, record::GBIF.GBIFRecord) where {T <: SimpleSDML
 end
 
 """
-    Base.setindex!(p::T, v, record::GBIFRecord) where {T <: SimpleSDMResponse}
+    Base.setindex!(layer::T, v, record::GBIFRecord) where {T <: SimpleSDMResponse}
 
 Changes the values of the cell including the point at the requested latitude and
 longitude. **Be careful**, this function will not update a cell that has
@@ -32,14 +32,14 @@ function Base.setindex!(layer::SimpleSDMResponse{T}, v::T, record::GBIF.GBIFReco
 end
 
 """
-    clip(p::T, r::GBIF.GBIFRecords)
+    clip(layer::T, records::GBIF.GBIFRecords)
 
 Returns a clipped version (with a 10% margin) around all occurences in a
 GBIFRecords collection.
 """
-function SimpleSDMLayers.clip(p::T, r::GBIF.GBIFRecords) where {T <: SimpleSDMLayer}
-   occ_latitudes = filter(!ismissing, [r[i].latitude for i in 1:length(r)])
-   occ_longitudes = filter(!ismissing, [r[i].longitude for i in 1:length(r)])
+function SimpleSDMLayers.clip(layer::T, records::GBIF.GBIFRecords) where {T <: SimpleSDMLayer}
+   occ_latitudes = filter(!ismissing, [records[i].latitude for i in 1:length(records)])
+   occ_longitudes = filter(!ismissing, [records[i].longitude for i in 1:length(records)])
 
    lat_min = minimum(occ_latitudes)
    lat_max = maximum(occ_latitudes)
@@ -58,11 +58,11 @@ function SimpleSDMLayers.clip(p::T, r::GBIF.GBIFRecords) where {T <: SimpleSDMLa
    lon_max = min(p.right, lon_max+lon_s)
    lon_min = max(p.left, lon_min-lon_s)
 
-   return p[left=lon_min, right=lon_max, bottom=lat_min, top=lat_max]
+   return layer[left=lon_min, right=lon_max, bottom=lat_min, top=lat_max]
 end
 
 """
-    Base.getindex(p::T, r::GBIF.GBIFRecords) where {T <: SimpleSDMLayer}
+    Base.getindex(layer::T, records::GBIF.GBIFRecords) where {T <: SimpleSDMLayer}
 
 Returns the values of a layer at all occurrences in a `GBIFRecords` collection.
 """
@@ -78,14 +78,14 @@ SimpleSDMLayers.latitudes(record::GBIF.GBIFRecord) = record.latitude
 
 Returns the non-missing latitudes.
 """
-SimpleSDMLayers.latitudes(records::GBIF.GBIFRecords) = filter(!ismissing, [latitudes(record) for i in 1:length(records)])
+SimpleSDMLayers.latitudes(records::GBIF.GBIFRecords) = filter(!ismissing, [latitudes(record) for record in records])
 
 """
     longitudes(records::GBIFRecords)
 
 Returns the non-missing longitudes.
 """
-SimpleSDMLayers.longitudes(records::GBIF.GBIFRecords) = filter(!ismissing, [longitudes(record) for i in 1:length(records)])
+SimpleSDMLayers.longitudes(records::GBIF.GBIFRecords) = filter(!ismissing, [longitudes(record) for record in records])
 
 """
     mask!(layer::SimpleSDMResponse{T}, records::GBIF.GBIFRecords) where {T <: AbstractBool}

--- a/src/lib/overloads.jl
+++ b/src/lib/overloads.jl
@@ -232,24 +232,7 @@ function Base.setindex!(layer::SimpleSDMResponse{T}, v::T, lon::Float64, lat::Fl
 end
 
 """
-    Base.similar(l::T) where {T <: SimpleSDMLayer}
-
-Returns a `SimpleSDMResponse` of the same dimensions as the original layer, with
-`nothing` in the same positions. The rest of the values are replaced by the
-output of `zero(eltype(layer.grid))`, which implies that there must be a way to
-get a zero for the type. If not, the same result can always be achieved through
-the use of `copy`, manual update, and `convert`.
-"""
-function Base.similar(layer::T) where {T <: SimpleSDMLayer}
-   emptygrid = similar(layer.grid)
-   for i in eachindex(emptygrid)
-      emptygrid[i] = isnothing(layer.grid[i]) ? nothing : zero(eltype(layer.grid[i]))
-   end
-   return SimpleSDMResponse(emptygrid, layer.left, layer.right, layer.bottom, layer.top)
-end
-
-"""
-    Base.similar(::Type{TC}, l::T) where {TC <: Any, T <: SimpleSDMLayer}
+    Base.similar(layer::T, ::Type{TC}) where {TC <: Any, T <: SimpleSDMLayer}
 
 Returns a `SimpleSDMResponse` of the same dimensions as the original layer, with
 `nothing` in the same positions. The rest of the values are replaced by the
@@ -257,10 +240,24 @@ output of `zero(TC)`, which implies that there must be a way to get a zero for
 the type. If not, the same result can always be achieved through the use of
 `copy`, manual update, and `convert`.
 """
-function Base.similar(::Type{TC}, layer::T) where {TC <: Any, T <: SimpleSDMLayer}
+function Base.similar(layer::T, ::Type{TC}) where {TC <: Any, T <: SimpleSDMLayer}
    emptygrid = convert(Matrix{Union{Nothing,TC}}, zeros(TC, size(layer)))
    emptygrid[findall(isnothing, layer.grid)] .= nothing
    return SimpleSDMResponse(emptygrid, layer.left, layer.right, layer.bottom, layer.top)
+end
+
+
+"""
+    Base.similar(layer::T) where {T <: SimpleSDMLayer}
+
+Returns a `SimpleSDMResponse` of the same dimensions as the original layer, with
+`nothing` in the same positions. The rest of the values are replaced by the
+output of `zero(element_type)`, which implies that there must be a way to get a
+zero for the type. If not, the same result can always be achieved through the
+use of `copy`, manual update, and `convert`.
+"""
+function Base.similar(layer::T) where {T <: SimpleSDMLayer}
+   return similar(layer, eltype(layer))
 end
 
 """

--- a/src/operations/mask.jl
+++ b/src/operations/mask.jl
@@ -1,5 +1,5 @@
-_inner_type(l::SimpleSDMResponse{T}) where {T <: Any} = T
-_inner_type(l::SimpleSDMPredictor{T}) where {T <: Any} = T
+_inner_type(::SimpleSDMResponse{T}) where {T <: Any} = T
+_inner_type(::SimpleSDMPredictor{T}) where {T <: Any} = T
 
 """
     mask!(l1::T1, l2::T2) where {T1 <: SimpleSDMLayer, T2 <: SimpleSDMLayer}

--- a/src/operations/sliding.jl
+++ b/src/operations/sliding.jl
@@ -48,8 +48,8 @@ function slidingwindow(layer::LT, f::FT, d::IT) where {LT <: SimpleSDMLayer, FT 
         N[p1.first...] = f(val)
     end
 
-    internal_types = unique(typeof.(N.grid))
-    N.grid = convert(Matrix{Union{internal_types...}}, N.grid)
+    #internal_types = unique(typeof.(N.grid))
+    #N.grid = convert(Matrix{Union{internal_types...}}, N.grid)
     N = typeof(layer) <: SimpleSDMPredictor ? convert(SimpleSDMPredictor, N) : N
 
     return N

--- a/test/gbif.jl
+++ b/test/gbif.jl
@@ -24,4 +24,15 @@ end
 
 @test typeof(clip(temperature, o)) == typeof(temperature)
 
+clpred = clip(temperature, o)
+
+mbool = mask(clpred, o, Bool)
+@test eltype(mbool) == Bool
+
+mfloat = mask(clpred, o, Float64)
+@test eltype(mfloat) == Float64
+
+@test sum(mfloat) >= sum(mbool)
+@test sum(mfloat) == length(o)
+
 end

--- a/test/overloads.jl
+++ b/test/overloads.jl
@@ -61,7 +61,7 @@ vl2 = vcat(l3, l4)
 @test all(vcat(ml1, ml2).grid == hcat(vl1, vl2).grid)
 
 # typed similar
-c2 = similar(Bool, l1)
+c2 = similar(l1, Bool)
 @test eltype(c2) == Bool
 
 end


### PR DESCRIPTION
**What the pull request does**   

Creates a layer to either have presence/absence of number of ocucrrences in a `GBIFRecords` query. 

:book: [Documentation](https://ecojulia.github.io/SimpleSDMLayers.jl/previews/PR65/)

:stop_sign:  Closes #60 
:information_source:  Helps with #61 and #64 
:question:  Might help with #59 as well

**Type of change**   

Please indicate the relevant option(s)

- [ ] :bug: Bug fix (non-breaking change which fixes an issue)
- [x] :sparkle: New feature (non-breaking change which adds functionality)
- [ ] :boom: Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] :book: This change requires a documentation update

**Checklist**

- [x] The changes are documented
  - [x] The docstrings of the different functions describe the arguments, purpose, and behavior 
  - [x] There are examples in the documentation website
- [x] The changes are tested
- [x] The changes **do not** modify the behavior of the previously existing functions
- [x] The `Project.toml` field `version` has been updated