### PR TITLE
Fix for #71

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SimpleSDMLayers"
 uuid = "2c645270-77db-11e9-22c3-0f302a89c64c"
 authors = ["Timothée Poisot <timothee.poisot@umontreal.ca>", "Gabriel Dansereau <gabriel.dansereau@umontreal.ca>"]
-version = "0.4.4"
+version = "0.4.5"
 
 [deps]
 ArchGDAL = "c9ce4bd3-c3d5-55b8-8973-c0e20141b8c3"

--- a/src/lib/overloads.jl
+++ b/src/lib/overloads.jl
@@ -13,6 +13,11 @@ import Base: hcat
 import Base: vcat
 import Base: show
 
+"""
+    Base.show(io::IO, layer::T) where {T <: SimpleSDMLayer}
+
+Shows a textual representation of the layer.
+"""
 function Base.show(io::IO, layer::T) where {T <: SimpleSDMLayer}
     itype = eltype(layer)
     otype = T <: SimpleSDMPredictor ? "predictor" : "response"

--- a/src/lib/overloads.jl
+++ b/src/lib/overloads.jl
@@ -46,14 +46,14 @@ function Base.convert(::Type{SimpleSDMPredictor}, layer::T) where {T <: SimpleSD
 end
 
 """
-    Base.convert(::Type{T}, layer::TL) where {T, TL <: SimpleSDMLayer}
+    Base.convert(::Type{T}, layer::TL) where {T <: Number, TL <: SimpleSDMLayer}
 
 Returns a copy of the layer with the same type (response or predictor), but the
-element type has been changed to `T`. This function is *extremely useful*
-(required, in fact) for plotting, as the `nothing` values are changed to `NaN`
-in the heatmaps.
+element type has been changed to `T` (which must be a number). This function is
+*extremely useful* (required, in fact) for plotting, as the `nothing` values are
+changed to `NaN` in the heatmaps.
 """
-function Base.convert(::Type{T}, layer::TL) where {T, TL <: SimpleSDMLayer}
+function Base.convert(::Type{T}, layer::TL) where {T <: Number, TL <: SimpleSDMLayer}
     new = similar(layer, T)
     new.grid[.!isnothing.(layer.grid)] .= convert.(T, layer.grid[.!isnothing.(layer.grid)])
     return new

--- a/src/lib/overloads.jl
+++ b/src/lib/overloads.jl
@@ -45,6 +45,14 @@ function Base.convert(::Type{SimpleSDMPredictor}, layer::T) where {T <: SimpleSD
    return copy(SimpleSDMPredictor(layer.grid, layer.left, layer.right, layer.bottom, layer.top))
 end
 
+"""
+    Base.convert(::Type{T}, layer::TL) where {T, TL <: SimpleSDMLayer}
+
+Returns a copy of the layer with the same type (response or predictor), but the
+element type has been changed to `T`. This function is *extremely useful*
+(required, in fact) for plotting, as the `nothing` values are changed to `NaN`
+in the heatmaps.
+"""
 function Base.convert(::Type{T}, layer::TL) where {T, TL <: SimpleSDMLayer}
     new = similar(layer, T)
     new.grid[.!isnothing.(layer.grid)] .= convert.(T, layer.grid[.!isnothing.(layer.grid)])

--- a/src/recipes/recipes.jl
+++ b/src/recipes/recipes.jl
@@ -2,9 +2,9 @@
 test 1
 """
 @recipe function plot(layer::T) where {T <: SimpleSDMLayer}
-    eltype(layer) <: Number || throw(ArgumentError("Plotting is only supported for layers with number values ($(eltype(layer)))"))
     seriestype --> :heatmap
     if get(plotattributes, :seriestype, :heatmap) in [:heatmap, :contour]
+        eltype(layer) <: AbstractFloat || throw(ArgumentError("This plot is only supported for layers with number values ($(eltype(layer)))"))
         aspect_ratio --> 1
         xlims --> extrema(longitudes(layer))
         ylims --> extrema(latitudes(layer))

--- a/src/recipes/recipes.jl
+++ b/src/recipes/recipes.jl
@@ -13,7 +13,7 @@ test 1
         lg = convert(Matrix{Float64}, lg)
         longitudes(layer), latitudes(layer), lg
     elseif get(plotattributes, :seriestype, :histogram) in [:histogram, :density]
-        collect(K)
+        collect(layer)
     elseif get(plotattributes, :seriestype, :surface) in [:surface, :wireframe]
         aspect_ratio --> 1
         xlims --> extrema(longitudes(layer))

--- a/src/recipes/recipes.jl
+++ b/src/recipes/recipes.jl
@@ -3,6 +3,7 @@ test 1
 """
 @recipe function plot(layer::T) where {T <: SimpleSDMLayer}
     eltype(layer) <: Number || throw(ArgumentError("Plotting is only supported for layers with number values ($(eltype(layer)))"))
+    K = convert(Float64, layer)
     seriestype --> :heatmap
     if get(plotattributes, :seriestype, :heatmap) in [:heatmap, :contour]
         aspect_ratio --> 1

--- a/src/recipes/recipes.jl
+++ b/src/recipes/recipes.jl
@@ -9,17 +9,17 @@ test 1
         aspect_ratio --> 1
         xlims --> extrema(longitudes(layer))
         ylims --> extrema(latitudes(layer))
-        lg = copy(layer.grid)
+        lg = copy(K.grid)
         replace!(lg, nothing => NaN)
         lg = convert(Matrix{Float64}, lg)
         longitudes(layer), latitudes(layer), lg
     elseif get(plotattributes, :seriestype, :histogram) in [:histogram, :density]
-        collect(layer)
+        collect(K)
     elseif get(plotattributes, :seriestype, :surface) in [:surface, :wireframe]
         aspect_ratio --> 1
         xlims --> extrema(longitudes(layer))
         ylims --> extrema(latitudes(layer))
-        lg = copy(layer.grid)
+        lg = copy(K.grid)
         replace!(lg, nothing => minimum(layer))
         lg = convert(Matrix{Float64}, lg)
         longitudes(layer), latitudes(layer), lg

--- a/src/recipes/recipes.jl
+++ b/src/recipes/recipes.jl
@@ -3,13 +3,12 @@ test 1
 """
 @recipe function plot(layer::T) where {T <: SimpleSDMLayer}
     eltype(layer) <: Number || throw(ArgumentError("Plotting is only supported for layers with number values ($(eltype(layer)))"))
-    K = convert(Float64, layer)
     seriestype --> :heatmap
     if get(plotattributes, :seriestype, :heatmap) in [:heatmap, :contour]
         aspect_ratio --> 1
         xlims --> extrema(longitudes(layer))
         ylims --> extrema(latitudes(layer))
-        lg = copy(K.grid)
+        lg = copy(layer.grid)
         replace!(lg, nothing => NaN)
         lg = convert(Matrix{Float64}, lg)
         longitudes(layer), latitudes(layer), lg
@@ -19,7 +18,7 @@ test 1
         aspect_ratio --> 1
         xlims --> extrema(longitudes(layer))
         ylims --> extrema(latitudes(layer))
-        lg = copy(K.grid)
+        lg = copy(layer.grid)
         replace!(lg, nothing => minimum(layer))
         lg = convert(Matrix{Float64}, lg)
         longitudes(layer), latitudes(layer), lg

--- a/test/overloads.jl
+++ b/test/overloads.jl
@@ -64,4 +64,7 @@ vl2 = vcat(l3, l4)
 c2 = similar(l1, Bool)
 @test eltype(c2) == Bool
 
+@test eltype(convert(Int64, c2)) == Int64
+@test eltype(convert(Float32, c2)) == Float32
+
 end

--- a/test/plots.jl
+++ b/test/plots.jl
@@ -94,7 +94,7 @@ a = convert(Matrix{Union{Bool,Nothing}}, a)
 a[rand(eachindex(a), 100)] .= nothing
 S = SimpleSDMResponse(a)
 
-plot(S)
+plot(convert(Int64, S))
 savefig(joinpath("gallery", "booltype.png"))
 
 end

--- a/test/plots.jl
+++ b/test/plots.jl
@@ -89,4 +89,12 @@ wireframe(t_europe, c=:thermal, title="Temperature",
     ylabel= "Latitude", camera=(40, 20))
 savefig(joinpath("gallery", "persp_40_20.png"))
 
+a = rand(Bool, 100, 100)
+a = convert(Matrix{Union{Bool,Nothing}}, a)
+a[rand(eachindex(a), 100)] .= nothing
+S = SimpleSDMResponse(a)
+
+plot(S)
+savefig(joinpath("gallery", "booltype.png"))
+
 end

--- a/test/plots.jl
+++ b/test/plots.jl
@@ -94,7 +94,7 @@ a = convert(Matrix{Union{Bool,Nothing}}, a)
 a[rand(eachindex(a), 100)] .= nothing
 S = SimpleSDMResponse(a)
 
-plot(convert(Int64, S))
+plot(convert(Float64, S))
 savefig(joinpath("gallery", "booltype.png"))
 
 end


### PR DESCRIPTION
Closes #71 

This adds a new `convert` method (and finally adds a `show` method) to change the element type of a layer. Useful to plot non-float things.