### PR TITLE
Fix DataFrames compatibility

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
 
 [compat]
 ArchGDAL = "0.4, 0.5, 0.6"
-Downloads = "1.4, 1.5"
+Downloads = "1.4"
 RecipesBase = "0.7, 0.8, 1.0"
 Requires = "1.0"
 ZipFile = "0.8, 0.9"

--- a/src/integrations/DataFrames.jl
+++ b/src/integrations/DataFrames.jl
@@ -76,7 +76,7 @@ function DataFrames.DataFrame(layers::Array{T}; kw...) where {T <: SimpleSDMLaye
     lons = repeat(longitudes(l1), inner = size(l1, 1))
     values = mapreduce(x -> vec(x.grid), hcat, layers)
     
-    df = DataFrames.DataFrame(values; kw...)
+    df = DataFrames.DataFrame(values, :auto; kw...)
     DataFrames.insertcols!(df, 1, :latitude => lats)
     DataFrames.insertcols!(df, 1, :longitude => lons)
     return df

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -6,5 +6,5 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-DataFrames = "0.21, 0.22"
+DataFrames = "0.21, 0.22, 1.0"
 GBIF = "0.2, 0.3"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -6,4 +6,5 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
+DataFrames = "0.21"
 GBIF = "0.2, 0.3"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -6,5 +6,5 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-DataFrames = "0.21"
+DataFrames = "0.21, 0.22"
 GBIF = "0.2, 0.3"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -6,5 +6,5 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-DataFrames = "0.21, 0.22, 1.0"
+DataFrames = "0.22, 1.0"
 GBIF = "0.2, 0.3"


### PR DESCRIPTION
**What the pull request does**   

DataFrames tests are currently failing because of a change between DataFrames v0.22.x and v1.0.0. I'll fix it and take a look at our compat entries at the same time.

Edit: Problem is fixed and the tests now pass. SimpleSDMLayers now works with DataFrames versions past v1.0. It still works with the v0.22.x series, but not v0.21.x. I removed the compat entry in the tests for v0.21.x.

**Type of change**   

Please indicate the relevant option(s)

- [x] :bug: Bug fix (non-breaking change which fixes an issue)
- [ ] :sparkle: New feature (non-breaking change which adds functionality)
- [ ] :boom: Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] :book: This change requires a documentation update

**Checklist**

- [ ] The changes are documented
  - [ ] The docstrings of the different functions describe the arguments, purpose, and behavior 
  - [ ] There are examples in the documentation website
- [ ] The changes are tested
- [ ] The changes **do not** modify the behavior of the previously existing functions
  - If they **do**, please explain why and how in the introduction paragraph
- [ ] For **new contributors** - my name and information are added to `.zenodo.json`
- [ ] The `Project.toml` field `version` has been updated
  - Change the *last* number for a `v0.0.x` series release, a bug fix, or a performance improvement
  - Change the *middle* number for additional features that *do not* break the current test suite (unless you fix a bug in the test suite)
  - Change the *first* number for changes that break the current test suite
