### PR TITLE
Remove outdated compat entries

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
 
 [compat]
-ArchGDAL = "0.4, 0.5, 0.6"
+ArchGDAL = "0.6"
 Downloads = "1.4"
 RecipesBase = "0.7, 0.8, 1.0"
 Requires = "1.0"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -3,6 +3,7 @@ DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 GBIF = "ee291a33-5a6c-5552-a3c8-0f29a1181037"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+StatsPlots = "f3b207a7-027a-5e70-b257-86293d7955fd"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]

--- a/test/plots.jl
+++ b/test/plots.jl
@@ -2,6 +2,7 @@ module SSLTestPlots
 using SimpleSDMLayers
 using Test
 using Plots
+using StatsPlots
 
 temperature, precipitation = SimpleSDMPredictor(WorldClim, BioClim, [1,12])
 
@@ -64,6 +65,10 @@ yaxis!("Latitude")
 savefig(joinpath("gallery", "heatmap_scaledown.png"))
 
 histogram(precipitation, leg=false)
+xaxis!("Precipitation")
+savefig(joinpath("gallery", "histogram.png"))
+
+density(precipitation, leg=false)
 xaxis!("Precipitation")
 savefig(joinpath("gallery", "density.png"))
 

--- a/test/plots.jl
+++ b/test/plots.jl
@@ -37,7 +37,7 @@ for (i,e) in enumerate(lc1.grid)
   n_lc1[i] = isnothing(e) ? NaN : Float32(e)
 end
 lc1 = SimpleSDMPredictor(n_lc1, lc1)
-plot(lc1, c=:terrain, title="Landcover class 1", frame=:box,
+plot(lc1, c=:heat, title="Landcover class 1", frame=:box,
     xlabel = "Longitude",
     ylabel= "Latitude")
 savefig(joinpath("gallery", "range-comparison-landcover.png"))


### PR DESCRIPTION
**What the pull request does**   

Following #96, I'm testing the compat entries by running the tests locally. The first one I tried, ArchGDAL, had compat entries for which SimpleSDMLayers didn't work.

Edit: Except ArchGDAL, all compat entries worked. I also added a test for `density` from StatsPlots, and replaced a color so versions of Plots prior to v1.1.0 can also run the tests.

**Type of change**   

Please indicate the relevant option(s)

- [x] :bug: Bug fix (non-breaking change which fixes an issue)
- [ ] :sparkle: New feature (non-breaking change which adds functionality)
- [ ] :boom: Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] :book: This change requires a documentation update

**Checklist**

- [ ] The changes are documented
  - [ ] The docstrings of the different functions describe the arguments, purpose, and behavior 
  - [ ] There are examples in the documentation website
- [ ] The changes are tested
- [ ] The changes **do not** modify the behavior of the previously existing functions
  - If they **do**, please explain why and how in the introduction paragraph
- [ ] For **new contributors** - my name and information are added to `.zenodo.json`
- [ ] The `Project.toml` field `version` has been updated
  - Change the *last* number for a `v0.0.x` series release, a bug fix, or a performance improvement
  - Change the *middle* number for additional features that *do not* break the current test suite (unless you fix a bug in the test suite)
  - Change the *first* number for changes that break the current test suite
