### PR TITLE
Add indentation in show method

### DIFF
--- a/src/lib/overloads.jl
+++ b/src/lib/overloads.jl
@@ -24,8 +24,8 @@ function Base.show(io::IO, layer::T) where {T <: SimpleSDMLayer}
     itype = eltype(layer)
     otype = T <: SimpleSDMPredictor ? "predictor" : "response"
     print(io, """SDM $(otype) → $(size(layer,1))×$(size(layer,2)) grid with $(length(layer)) $(itype)-valued cells
-    Latitudes\t$(extrema(latitudes(layer)))
-    Longitudes\t$(extrema(longitudes(layer)))""")
+    \x20\x20Latitudes\t$(extrema(latitudes(layer)))
+    \x20\x20Longitudes\t$(extrema(longitudes(layer)))""")
 end
 
 """

--- a/src/lib/overloads.jl
+++ b/src/lib/overloads.jl
@@ -16,16 +16,23 @@ import Base: vcat
 import Base: show
 
 """
+    Base.show(io::IO, ::MIME"text/plain", layer::T) where {T <: SimpleSDMLayer}
     Base.show(io::IO, layer::T) where {T <: SimpleSDMLayer}
 
 Shows a textual representation of the layer.
 """
-function Base.show(io::IO, layer::T) where {T <: SimpleSDMLayer}
+function Base.show(io::IO, ::MIME"text/plain", layer::T) where {T <: SimpleSDMLayer}
     itype = eltype(layer)
     otype = T <: SimpleSDMPredictor ? "predictor" : "response"
     print(io, """SDM $(otype) → $(size(layer,1))×$(size(layer,2)) grid with $(length(layer)) $(itype)-valued cells
     \x20\x20Latitudes\t$(extrema(latitudes(layer)))
     \x20\x20Longitudes\t$(extrema(longitudes(layer)))""")
+end
+
+function Base.show(io::IO, layer::T) where {T <: SimpleSDMLayer}
+    itype = eltype(layer)
+    otype = T <: SimpleSDMPredictor ? "predictor" : "response"
+    print(io, "SDM $(otype) → $(size(layer,1))×$(size(layer,2)) grid with $(length(layer)) $(itype)-valued cells")
 end
 
 """


### PR DESCRIPTION
**What the pull request does**   

I really like the `show` methods but I think we should add some indentation before the coordinates on the 2nd and 3rd lines to differentiate them from the layer type on the 1st line. Especially for `Vector{SimpleSDMLayer}` with multiple elements, where it can get hard to see the different layers.

I tried a couple things, so I'll commit each one separately and add a comment showing the result.

Here's the output _before the changes in this PR_:

```julia
julia> layer = SimpleSDMPredictor(WorldClim, BioClim, 1)
SDM predictor → 1080×2160 grid with 808053 Float32-valued cells
Latitudes       (-89.91666666666667, 89.91666666666667)
Longitudes      (-179.91666666666666, 179.91666666666666)

julia> layers = SimpleSDMPredictor(WorldClim, BioClim, 1:2)
2-element Vector{SimpleSDMPredictor{Float32}}:
 SDM predictor → 1080×2160 grid with 808053 Float32-valued cells
Latitudes       (-89.91666666666667, 89.91666666666667)
Longitudes      (-179.91666666666666, 179.91666666666666)
 SDM predictor → 1080×2160 grid with 808053 Float32-valued cells
Latitudes       (-89.91666666666667, 89.91666666666667)
Longitudes      (-179.91666666666666, 179.91666666666666)
```

**Type of change**   

Please indicate the relevant option(s)

- [x] :bug: Bug fix (non-breaking change which fixes an issue)
- [ ] :sparkle: New feature (non-breaking change which adds functionality)
- [ ] :boom: Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] :book: This change requires a documentation update

**Checklist**

- [x] The changes are documented
  - [x] The docstrings of the different functions describe the arguments, purpose, and behavior 
  - [x] There are examples in the documentation website
- [x] The changes are tested
- [x] The changes **do not** modify the behavior of the previously existing functions
  - If they **do**, please explain why and how in the introduction paragraph
- [x] For **new contributors** - my name and information are added to `.zenodo.json`
- [x] The `Project.toml` field `version` has been updated
  - Change the *last* number for a `v0.0.x` series release, a bug fix, or a performance improvement
  - Change the *middle* number for additional features that *do not* break the current test suite (unless you fix a bug in the test suite)
  - Change the *first* number for changes that break the current test suite
