### PR TITLE
Fix layer dimensions bugs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - '1.5'
+          - '1.6'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SimpleSDMLayers"
 uuid = "2c645270-77db-11e9-22c3-0f302a89c64c"
 authors = ["Timothée Poisot <timothee.poisot@umontreal.ca>", "Gabriel Dansereau <gabriel.dansereau@umontreal.ca>"]
-version = "0.6.0"
+version = "0.7.0"
 
 [deps]
 ArchGDAL = "c9ce4bd3-c3d5-55b8-8973-c0e20141b8c3"

--- a/src/datasets/geotiff.jl
+++ b/src/datasets/geotiff.jl
@@ -1,9 +1,21 @@
-function _find_span(n, m, M, pos)
+function _find_span(n, m, M, pos, side)
+    side in [:left, :right, :bottom, :top] || throw(ArgumentError("side must be one of :left, :right, :bottom, top"))
+    
     pos > M && return nothing
     pos < m && return nothing
     stride = (M - m) / n
     centers = (m + 0.5stride):stride:(M-0.5stride)
-    span_pos = last(findmin(abs.(pos .- centers)))
+    pos_diff = abs.(pos .- centers)
+    pos_approx = isapprox.(pos_diff, 0.5stride)
+    if any(pos_approx)
+        if side in [:left, :bottom]
+            span_pos = findlast(pos_approx)
+        elseif side in [:right, :top]
+            span_pos = findfirst(pos_approx)
+        end
+    else
+        span_pos = last(findmin(abs.(pos .- centers)))
+    end
     return (stride, centers[span_pos], span_pos)
 end
 
@@ -64,10 +76,10 @@ function geotiff(
         #global left_pos, right_pos
         #global bottom_pos, top_pos
 
-        lon_stride, left_pos, min_width = _find_span(width, minlon, maxlon, left)
-        _, right_pos, max_width = _find_span(width, minlon, maxlon, right)
-        lat_stride, top_pos, max_height = _find_span(height, minlat, maxlat, top)
-        _, bottom_pos, min_height = _find_span(height, minlat, maxlat, bottom)
+        lon_stride, left_pos, min_width = _find_span(width, minlon, maxlon, left, :left)
+        _, right_pos, max_width = _find_span(width, minlon, maxlon, right, :right)
+        lat_stride, top_pos, max_height = _find_span(height, minlat, maxlat, top, :top)
+        _, bottom_pos, min_height = _find_span(height, minlat, maxlat, bottom, :bottom)
 
         max_height, min_height = height .- (min_height, max_height) .+ 1
 

--- a/src/datasets/geotiff.jl
+++ b/src/datasets/geotiff.jl
@@ -102,11 +102,7 @@ Write a single `layer` to a `file`, where the `nodata` field is set to an
 arbitrary value.
 """
 function geotiff(file::AbstractString, layer::SimpleSDMPredictor{T}; nodata::T=convert(T, -9999)) where {T <: Number}
-    array = layer.grid
-    replace!(array, nothing => NaN)
-    array = convert(Matrix{T}, array)
-    dtype = eltype(array)
-    array_t = reverse(permutedims(array, [2, 1]); dims=2)
+    array_t = _prepare_layer_for_burnin(layer)
     width, height = size(array_t)
 
     # Geotransform
@@ -144,8 +140,7 @@ end
 
 function _prepare_layer_for_burnin(layer::T) where {T <: SimpleSDMLayer}
     @assert eltype(layer) <: Number
-    array = layer.grid
-    replace!(array, nothing => NaN)
+    array = replace(layer.grid, nothing => NaN)
     array = convert(Matrix{eltype(layer)}, array)
     dtype = eltype(array)
     array_t = reverse(permutedims(array, [2, 1]); dims=2)

--- a/src/lib/basics.jl
+++ b/src/lib/basics.jl
@@ -4,7 +4,7 @@
 Returns an iterator with the latitudes of the SDM layer passed as its argument.
 This returns the latitude at the center of each cell in the grid.
 """
-latitudes(layer::T) where {T <: SimpleSDMLayer} = LinRange(layer.bottom+stride(layer, 2), layer.top-stride(layer, 2), size(layer,1))
+latitudes(layer::T) where {T <: SimpleSDMLayer} = range(layer.bottom+stride(layer, 2), layer.top-stride(layer, 2); length=size(layer,1))
 
 """
     longitudes(layer::T) where {T <: SimpleSDMLayer}
@@ -12,7 +12,7 @@ latitudes(layer::T) where {T <: SimpleSDMLayer} = LinRange(layer.bottom+stride(l
 Returns an iterator with the longitudes of the SDM layer passed as its argument.
 This returns the longitudes at the center of each cell in the grid.
 """
-longitudes(layer::T) where {T <: SimpleSDMLayer} = LinRange(layer.left+stride(layer, 1), layer.right-stride(layer, 1), size(layer,2))
+longitudes(layer::T) where {T <: SimpleSDMLayer} = range(layer.left+stride(layer, 1), layer.right-stride(layer, 1); length=size(layer,2))
 
 """
     _layers_are_compatible(l1::X, l2::Y) where {X <: SimpleSDMLayer, Y <: SimpleSDMLayer}

--- a/src/lib/overloads.jl
+++ b/src/lib/overloads.jl
@@ -25,8 +25,8 @@ function Base.show(io::IO, ::MIME"text/plain", layer::T) where {T <: SimpleSDMLa
     itype = eltype(layer)
     otype = T <: SimpleSDMPredictor ? "predictor" : "response"
     print(io, """SDM $(otype) → $(size(layer,1))×$(size(layer,2)) grid with $(length(layer)) $(itype)-valued cells
-    \x20\x20Latitudes\t$(extrema(latitudes(layer)))
-    \x20\x20Longitudes\t$(extrema(longitudes(layer)))""")
+    \x20\x20Latitudes\t$(Tuple(latitudes(layer)[[1, end]]))
+    \x20\x20Longitudes\t$(Tuple(longitudes(layer)[[1, end]]))""")
 end
 
 function Base.show(io::IO, layer::T) where {T <: SimpleSDMLayer}

--- a/src/lib/overloads.jl
+++ b/src/lib/overloads.jl
@@ -168,6 +168,9 @@ range, or the grid index containing this latitude if it is within range
 function _match_latitude(layer::T, lat::K; side=:none) where {T <: SimpleSDMLayer, K <: AbstractFloat}
     side in [:none, :bottom, :top] || throw(ArgumentError("side must be one of :none (default), :bottom, :top"))
 
+    lat > layer.top && return nothing
+    lat < layer.bottom && return nothing
+
     ldiff = abs.(lat .- latitudes(layer))
     if side == :none || !any(x -> isapprox(x, stride(layer, 2)), ldiff)
         l = last(findmin(ldiff))

--- a/src/lib/overloads.jl
+++ b/src/lib/overloads.jl
@@ -365,26 +365,26 @@ end
 """
     Base.vcat(l1::T, l2::T) where {T <: SimpleSDMLayers}
 
-Adds the second layer *under* the first one, assuming the strides and left/right
-coordinates match. This will automatically re-order the layers if the second is
-above the first.
+Adds the second layer *under* the first one (according to coordinates), 
+assuming the strides and left/right coordinates match. This will automatically
+re-order the layers if the second is above the first.
 """
 function Base.vcat(l1::T, l2::T) where {T <: SimpleSDMLayer}
     (l1.left == l2.left) || throw(ArgumentError("The two layers passed to vcat must have the same left coordinate"))
     (l1.right == l2.right) || throw(ArgumentError("The two layers passed to vcat must have the same right coordinate"))
     all(stride(l1) .≈ stride(l2)) || throw(ArgumentError("The two layers passed to vcat must have the same stride"))
-    (l2.top == l1.bottom) && return vcat(l2, l1)
-    new_grid = vcat(l1.grid, l2.grid)
+    (l1.top == l2.bottom) && return vcat(l2, l1)
+    new_grid = vcat(l2.grid, l1.grid)
     RT = T <: SimpleSDMPredictor ? SimpleSDMPredictor : SimpleSDMResponse
-    return RT(new_grid, l1.left, l1.right, l1.top, l2.bottom)
+    return RT(new_grid, l1.left, l1.right, l2.bottom, l1.top)
 end
 
 """
     Base.hcat(l1::T, l2::T) where {T <: SimpleSDMLayers}
 
-Adds the second layer *to the right of* the first one, assuming the strides and
-left/right coordinates match. This will automatically re-order the layers if the
-second is to the left the first.
+Adds the second layer *to the right of* the first one (according to coordinaters),
+assuming the strides and left/right coordinates match. This will automatically 
+re-order the layers if the second is to the left the first.
 """
 function Base.hcat(l1::T, l2::T) where {T <: SimpleSDMLayer}
     (l1.top == l2.top) || throw(ArgumentError("The two layers passed to hcat must have the same top coordinate"))
@@ -393,7 +393,7 @@ function Base.hcat(l1::T, l2::T) where {T <: SimpleSDMLayer}
     (l2.right == l1.left) && return hcat(l2, l1)
     new_grid = hcat(l1.grid, l2.grid)
     RT = T <: SimpleSDMPredictor ? SimpleSDMPredictor : SimpleSDMResponse
-    return RT(new_grid, l1.left, l2.right, l1.top, l1.bottom)
+    return RT(new_grid, l1.left, l2.right, l1.bottom, l1.top)
 end
 
 """

--- a/src/lib/overloads.jl
+++ b/src/lib/overloads.jl
@@ -172,12 +172,13 @@ function _match_latitude(layer::T, lat::K; side=:none) where {T <: SimpleSDMLaye
     lat < layer.bottom && return nothing
 
     ldiff = abs.(lat .- latitudes(layer))
-    if side == :none || !any(x -> isapprox(x, stride(layer, 2)), ldiff)
+    lapprox = isapprox.(ldiff, stride(layer, 2))
+    if side == :none || !any(lapprox)
         l = last(findmin(ldiff))
     elseif side == :bottom
-        l = findlast(x -> isapprox(x, stride(layer, 2)), ldiff)
+        l = findlast(lapprox)
     elseif side == :top
-        l = findfirst(x -> isapprox(x, stride(layer, 2)), ldiff)
+        l = findfirst(lapprox)
     end
     
     return l
@@ -195,12 +196,13 @@ function _match_longitude(layer::T, lon::K; side::Symbol=:none) where {T <: Simp
     lon < layer.left && return nothing
     
     ldiff = abs.(lon .- longitudes(layer))
-    if side == :none || !any(x -> isapprox(x, stride(layer, 1)), ldiff)
+    lapprox = isapprox.(ldiff, stride(layer, 1))
+    if side == :none || !any(lapprox)
         l = last(findmin(ldiff))
     elseif side == :left
-        l = findlast(x -> isapprox(x, stride(layer, 1)), ldiff)
+        l = findlast(lapprox)
     elseif side == :right
-        l = findfirst(x -> isapprox(x, stride(layer, 1)), ldiff)
+        l = findfirst(lapprox)
     end
 
     return l

--- a/src/lib/overloads.jl
+++ b/src/lib/overloads.jl
@@ -374,6 +374,7 @@ function Base.vcat(l1::T, l2::T) where {T <: SimpleSDMLayer}
     (l1.right == l2.right) || throw(ArgumentError("The two layers passed to vcat must have the same right coordinate"))
     all(stride(l1) .≈ stride(l2)) || throw(ArgumentError("The two layers passed to vcat must have the same stride"))
     (l1.top == l2.bottom) && return vcat(l2, l1)
+    (l2.top == l1.bottom) || throw(ArgumentError("The two layers passed to vcat must have contiguous bottom and top coordinates"))
     new_grid = vcat(l2.grid, l1.grid)
     RT = T <: SimpleSDMPredictor ? SimpleSDMPredictor : SimpleSDMResponse
     return RT(new_grid, l1.left, l1.right, l2.bottom, l1.top)
@@ -382,7 +383,7 @@ end
 """
     Base.hcat(l1::T, l2::T) where {T <: SimpleSDMLayers}
 
-Adds the second layer *to the right of* the first one (according to coordinaters),
+Adds the second layer *to the right of* the first one (according to coordinates),
 assuming the strides and left/right coordinates match. This will automatically 
 re-order the layers if the second is to the left the first.
 """
@@ -391,6 +392,7 @@ function Base.hcat(l1::T, l2::T) where {T <: SimpleSDMLayer}
     (l1.bottom == l2.bottom) || throw(ArgumentError("The two layers passed to hcat must have the same bottom coordinate"))
     all(stride(l1) .≈ stride(l2)) || throw(ArgumentError("The two layers passed to hcat must have the same stride"))
     (l2.right == l1.left) && return hcat(l2, l1)
+    (l1.right == l2.left) || throw(ArgumentError("The two layers passed to hcat must have contiguous left and right coordinates"))
     new_grid = hcat(l1.grid, l2.grid)
     RT = T <: SimpleSDMPredictor ? SimpleSDMPredictor : SimpleSDMResponse
     return RT(new_grid, l1.left, l2.right, l1.bottom, l1.top)

--- a/src/lib/overloads.jl
+++ b/src/lib/overloads.jl
@@ -41,7 +41,7 @@ end
 Returns a response with the same grid and bounding box as the predictor.
 """
 function Base.convert(::Type{SimpleSDMResponse}, layer::T) where {T <: SimpleSDMPredictor}
-   return copy(SimpleSDMResponse(layer.grid, layer.left, layer.right, layer.bottom, layer.top))
+    return copy(SimpleSDMResponse(layer.grid, layer.left, layer.right, layer.bottom, layer.top))
 end
 
 """
@@ -50,7 +50,7 @@ end
 Returns a predictor with the same grid and bounding box as the response.
 """
 function Base.convert(::Type{SimpleSDMPredictor}, layer::T) where {T <: SimpleSDMResponse}
-   return copy(SimpleSDMPredictor(layer.grid, layer.left, layer.right, layer.bottom, layer.top))
+    return copy(SimpleSDMPredictor(layer.grid, layer.left, layer.right, layer.bottom, layer.top))
 end
 
 """
@@ -73,7 +73,7 @@ end
 Returns the grid as an array.
 """
 function Base.convert(::Type{Matrix}, layer::T) where {T <: SimpleSDMLayer}
-   return copy(layer.grid)
+    return copy(layer.grid)
 end
 
 """
@@ -110,11 +110,11 @@ alongside a side of the grid. The first position is the length of the
 *longitude* cells, the second the *latitude*.
 """
 function Base.stride(layer::T; dims::Union{Nothing,Integer}=nothing) where {T <: SimpleSDMLayer}
-   lon_stride = (layer.right-layer.left)/2.0size(layer, 2)
-   lat_stride = (layer.top-layer.bottom)/2.0size(layer, 1)
-   isnothing(dims) && return (lon_stride, lat_stride)
-   dims == 1 && return lon_stride
-   dims == 2 && return lat_stride
+    lon_stride = (layer.right-layer.left)/2.0size(layer, 2)
+    lat_stride = (layer.top-layer.bottom)/2.0size(layer, 1)
+    isnothing(dims) && return (lon_stride, lat_stride)
+    dims == 1 && return lon_stride
+    dims == 2 && return lat_stride
 end
 Base.stride(layer::T, i::Int) where {T<:SimpleSDMLayer} = stride(layer; dims=i)
 
@@ -145,20 +145,20 @@ performs additional checks to ensure that the range is not empty, and to also
 ensure that it does not overflows from the size of the layer.
 """
 function Base.getindex(layer::T, i::R, j::R) where {T <: SimpleSDMLayer, R <: UnitRange}
-   i_min = isempty(i) ? max(i.start-1, 1) : i.start
-   i_max = isempty(i) ? max(i.stop+2, size(layer, 1)) : i.stop
-   j_min = isempty(j) ? max(j.start-1, 1) : j.start
-   j_max = isempty(j) ? max(j.stop+2, size(layer, 2)) : j.stop
-   i_fix = i_min:i_max
-   j_fix = j_min:j_max
-   RT = T <: SimpleSDMResponse ? SimpleSDMResponse : SimpleSDMPredictor
-   return RT(
-            layer.grid[i_fix,j_fix],
-            minimum(longitudes(layer)[j_fix])-stride(layer,1),
-            maximum(longitudes(layer)[j_fix])+stride(layer,1),
-            minimum(latitudes(layer)[i_fix])-stride(layer,2),
-            maximum(latitudes(layer)[i_fix])+stride(layer,2)
-           )
+    i_min = isempty(i) ? max(i.start-1, 1) : i.start
+    i_max = isempty(i) ? max(i.stop+2, size(layer, 1)) : i.stop
+    j_min = isempty(j) ? max(j.start-1, 1) : j.start
+    j_max = isempty(j) ? max(j.stop+2, size(layer, 2)) : j.stop
+    i_fix = i_min:i_max
+    j_fix = j_min:j_max
+    RT = T <: SimpleSDMResponse ? SimpleSDMResponse : SimpleSDMPredictor
+    return RT(
+        layer.grid[i_fix,j_fix],
+        minimum(longitudes(layer)[j_fix])-stride(layer,1),
+        maximum(longitudes(layer)[j_fix])+stride(layer,1),
+        minimum(latitudes(layer)[i_fix])-stride(layer,2),
+        maximum(latitudes(layer)[i_fix])+stride(layer,2)
+    )
 end
 
 """
@@ -166,9 +166,9 @@ Given a layer and a latitude, returns `nothing` if the latitude is outside the
 range, or the grid index containing this latitude if it is within range
 """
 function _match_latitude(layer::T, lat::K) where {T <: SimpleSDMLayer, K <: AbstractFloat}
-   lat > layer.top && return nothing
-   lat < layer.bottom && return nothing
-   return last(findmin(abs.(lat .- latitudes(layer))))
+    lat > layer.top && return nothing
+    lat < layer.bottom && return nothing
+    return last(findmin(abs.(lat .- latitudes(layer))))
 end
 
 
@@ -177,9 +177,9 @@ Given a layer and a longitude, returns `nothing` if the longitude is outside the
 range, or the grid index containing this longitude if it is within range
 """
 function _match_longitude(layer::T, lon::K) where {T <: SimpleSDMLayer, K <: AbstractFloat}
-   lon > layer.right && return nothing
-   lon < layer.left && return nothing
-   return last(findmin(abs.(lon .- longitudes(layer))))
+    lon > layer.right && return nothing
+    lon < layer.left && return nothing
+    return last(findmin(abs.(lon .- longitudes(layer))))
 end
 
 """
@@ -189,11 +189,11 @@ Extracts the value of a layer at a given latitude and longitude. If values
 outside the range are requested, will return `nothing`.
 """
 function Base.getindex(layer::T, longitude::K, latitude::K) where {T <: SimpleSDMLayer, K <: AbstractFloat}
-   i = _match_longitude(layer, longitude)
-   j = _match_latitude(layer, latitude)
-   isnothing(i) && return nothing
-   isnothing(j) && return nothing
-   return layer.grid[j, i]
+    i = _match_longitude(layer, longitude)
+    j = _match_latitude(layer, latitude)
+    isnothing(i) && return nothing
+    isnothing(j) && return nothing
+    return layer.grid[j, i]
 end
 
 """
@@ -204,18 +204,18 @@ Returns a subset of the argument layer, where the new limits are given by
 if so these limits will not be affected.
 """
 function Base.getindex(layer::T; left=nothing, right=nothing, top=nothing, bottom=nothing) where {T <: SimpleSDMLayer}
-   for limit in [left, right, top, bottom]
-      if !isnothing(limit)
-         @assert typeof(limit) <: AbstractFloat
-      end
-   end
-   imax = _match_longitude(layer, isnothing(right) ? layer.right : right)
-   imin = _match_longitude(layer, isnothing(left) ? layer.left : left)
-   jmax = _match_latitude(layer, isnothing(top) ? layer.top : top)
-   jmin = _match_latitude(layer, isnothing(bottom) ? layer.bottom : bottom)
-   any(isnothing.([imin, imax, jmin, jmax])) && throw(ArgumentError("Unable to extract, coordinates outside of range"))
-   # Note that this is LATITUDE first
-   return layer[jmin:jmax, imin:imax]
+    for limit in [left, right, top, bottom]
+       if !isnothing(limit)
+          @assert typeof(limit) <: AbstractFloat
+       end
+    end
+    imax = _match_longitude(layer, isnothing(right) ? layer.right : right)
+    imin = _match_longitude(layer, isnothing(left) ? layer.left : left)
+    jmax = _match_latitude(layer, isnothing(top) ? layer.top : top)
+    jmin = _match_latitude(layer, isnothing(bottom) ? layer.bottom : bottom)
+    any(isnothing.([imin, imax, jmin, jmax])) && throw(ArgumentError("Unable to extract, coordinates outside of range"))
+    # Note that this is LATITUDE first
+    return layer[jmin:jmax, imin:imax]
 end
 
 """
@@ -241,8 +241,8 @@ Extract a layer based on a second layer. Note that the two layers must be
 size.
 """
 function Base.getindex(layer1::T1, layer2::T2) where {T1 <: SimpleSDMLayer, T2 <: SimpleSDMLayer}
-   SimpleSDMLayers._layers_are_compatible(layer1, layer2)
-   return layer1[left=layer2.left, right=layer2.right, bottom=layer2.bottom, top=layer2.top]
+    SimpleSDMLayers._layers_are_compatible(layer1, layer2)
+    return layer1[left=layer2.left, right=layer2.right, bottom=layer2.bottom, top=layer2.top]
 end
 
 """
@@ -252,8 +252,8 @@ Changes the value of a cell, or a range of cells, as indicated by their grid
 positions.
 """
 function Base.setindex!(layer::SimpleSDMResponse{T}, v::T, i...) where {T}
-   typeof(v) <: eltype(layer.grid) || throw(ArgumentError("Impossible to set a value to a non-matching type"))
-   layer.grid[i...] = v
+    typeof(v) <: eltype(layer.grid) || throw(ArgumentError("Impossible to set a value to a non-matching type"))
+    layer.grid[i...] = v
 end
 
 """
@@ -263,9 +263,9 @@ Changes the values of the cell including the point at the requested latitude and
 longitude.
 """
 function Base.setindex!(layer::SimpleSDMResponse{T}, v::T, lon::Float64, lat::Float64) where {T}
-   i = _match_longitude(layer, lon)
-   j = _match_latitude(layer, lat)
-   layer[j,i] = v
+    i = _match_longitude(layer, lon)
+    j = _match_latitude(layer, lat)
+    layer[j,i] = v
 end
 
 """
@@ -278,9 +278,9 @@ the type. If not, the same result can always be achieved through the use of
 `copy`, manual update, and `convert`.
 """
 function Base.similar(layer::T, ::Type{TC}) where {TC <: Any, T <: SimpleSDMLayer}
-   emptygrid = convert(Matrix{Union{Nothing,TC}}, zeros(TC, size(layer)))
-   emptygrid[findall(isnothing, layer.grid)] .= nothing
-   return SimpleSDMResponse(emptygrid, layer.left, layer.right, layer.bottom, layer.top)
+    emptygrid = convert(Matrix{Union{Nothing,TC}}, zeros(TC, size(layer)))
+    emptygrid[findall(isnothing, layer.grid)] .= nothing
+    return SimpleSDMResponse(emptygrid, layer.left, layer.right, layer.bottom, layer.top)
 end
 
 
@@ -294,7 +294,7 @@ zero for the type. If not, the same result can always be achieved through the
 use of `copy`, manual update, and `convert`.
 """
 function Base.similar(layer::T) where {T <: SimpleSDMLayer}
-   return similar(layer, eltype(layer))
+    return similar(layer, eltype(layer))
 end
 
 """
@@ -303,9 +303,9 @@ end
 Returns a new copy of the layer, which has the same type.
 """
 function Base.copy(layer::T) where {T <: SimpleSDMLayer}
-   copygrid = copy(layer.grid)
-   RT = T <: SimpleSDMResponse ? SimpleSDMResponse : SimpleSDMPredictor
-   return RT(copygrid, copy(layer.left), copy(layer.right), copy(layer.bottom), copy(layer.top))
+    copygrid = copy(layer.grid)
+    RT = T <: SimpleSDMResponse ? SimpleSDMResponse : SimpleSDMPredictor
+    return RT(copygrid, copy(layer.left), copy(layer.right), copy(layer.bottom), copy(layer.top))
 end
 
 """

--- a/src/lib/types.jl
+++ b/src/lib/types.jl
@@ -23,6 +23,8 @@ struct SimpleSDMPredictor{T} <: SimpleSDMLayer
     bottom::AbstractFloat
     top::AbstractFloat
     function SimpleSDMPredictor(grid::Matrix{Union{Nothing,T}}, l::K, r::K, b::K, t::K) where {T, K<:AbstractFloat}
+        r < l && throw(ArgumentError("The right bounding coordinate must be greater than the right one"))
+        t < b && throw(ArgumentError("The top bounding coordinate must be greater than the bottom one"))
         return new{T}(grid, l, r, b, t)
     end
 end
@@ -38,6 +40,8 @@ mutable struct SimpleSDMResponse{T} <: SimpleSDMLayer
     bottom::AbstractFloat
     top::AbstractFloat
     function SimpleSDMResponse(grid::Matrix{Union{Nothing,T}}, l::K, r::K, b::K, t::K) where {T, K<:AbstractFloat}
+        r < l && throw(ArgumentError("The right bounding coordinate must be greater than the right bounding coordinate"))
+        t < b && throw(ArgumentError("The top bounding coordinate must be greater than the bottom bounding coordinate"))
         return new{T}(grid, l, r, b, t)
     end
 end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -5,13 +5,13 @@ using Test
 M = rand(Bool, (3,5))
 S = SimpleSDMPredictor(M, 0.0, 1.0, 0.0, 1.0)
 
-@assert longitudes(S) == LinRange(0.1, 0.9, 5)
-@assert latitudes(S) == LinRange(1/6, 5/6, 3)
+@test longitudes(S) == range(0.1, 0.9; length=5)
+@test latitudes(S) == range(1/6, 5/6; length=3)
 
 M = rand(Bool, (4,3))
 S = SimpleSDMPredictor(M, 0.2, 1.8, -1.0, 2.0)
 
-@assert longitudes(S) == LinRange(S.left+stride(S,1), S.right-stride(S,1), size(S,2))
-@assert latitudes(S) == LinRange(S.bottom+stride(S,2), S.top-stride(S,2), size(S,1))
+@test longitudes(S) == range(S.left+stride(S,1), S.right-stride(S,1); length=size(S,2))
+@test latitudes(S) == range(S.bottom+stride(S,2), S.top-stride(S,2); length=size(S,1))
 
 end

--- a/test/overloads.jl
+++ b/test/overloads.jl
@@ -52,13 +52,29 @@ l1 = SimpleSDMPredictor(WorldClim, BioClim, 1; left=0.0, right=10.0, bottom=0.0,
 l2 = SimpleSDMPredictor(WorldClim, BioClim, 1; left=0.0, right=10.0, bottom=10.0, top=20.0)
 l3 = SimpleSDMPredictor(WorldClim, BioClim, 1; left=10.0, right=20.0, bottom=0.0, top=10.0)
 l4 = SimpleSDMPredictor(WorldClim, BioClim, 1; left=10.0, right=20.0, bottom=10.0, top=20.0)
+l5 = SimpleSDMPredictor(WorldClim, BioClim, 1; left=0.0, right=20.0, bottom=0.0, top=20.0)
 
 ml1 = hcat(l1, l3)
 vl1 = vcat(l1, l2)
 ml2 = hcat(l2, l4)
 vl2 = vcat(l3, l4)
 
-@test all(vcat(ml1, ml2).grid == hcat(vl1, vl2).grid)
+vml = vcat(ml1, ml2)
+mvl = hcat(vl1, vl2)
+
+@test all(vml.grid == mvl.grid)
+
+for l in (vml, mvl)
+   @test all(l.grid == l5.grid)
+   @test size(l) == size(l5)
+   @test stride(l) == stride(l5)
+   @test longitudes(l) == longitudes(l5)
+   @test latitudes(l) == latitudes(l5)
+   @test l.left == l5.left
+   @test l.right == l5.right
+   @test l.bottom == l5.bottom
+   @test l.top == l5.top
+end
 
 # typed similar
 c2 = similar(l1, Bool)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,7 @@ tests = [
    "worldclim" => "worldclim.jl",
    "earthenv" => "earthenv.jl",
    "chelsa" => "chelsa.jl",
+   "subsetting" => "subsetting.jl",
    "coarsen" => "coarsen.jl",
    "plotting" => "plots.jl",
    "GBIF" => "gbif.jl",

--- a/test/subsetting.jl
+++ b/test/subsetting.jl
@@ -9,4 +9,15 @@ coords = (left = -145.0, right = -50.0, bottom = 20.0, top = 75.0)
 layer = temp[coords]
 @test size(layer) == (330, 570)
 
+@test layer.left == coords.left
+@test layer.right == coords.right
+@test layer.bottom == coords.bottom
+@test layer.top == coords.top
+
+@test stride(layer) == stride(temp)
+@test longitudes(layer)[1] == -144.91666666666666
+@test longitudes(layer)[end] == -50.083333333333336
+@test latitudes(layer)[1] == 20.083333333333332
+@test latitudes(layer)[end] == 74.91666666666667
+
 end

--- a/test/subsetting.jl
+++ b/test/subsetting.jl
@@ -6,18 +6,25 @@ temp = SimpleSDMPredictor(WorldClim, BioClim, 1)
 @test size(temp) == (1080, 2160)
 
 coords = (left = -145.0, right = -50.0, bottom = 20.0, top = 75.0)
-layer = temp[coords]
-@test size(layer) == (330, 570)
+l1 = temp[coords]
+l2 = SimpleSDMPredictor(WorldClim, BioClim, 1; coords...)
 
-@test layer.left == coords.left
-@test layer.right == coords.right
-@test layer.bottom == coords.bottom
-@test layer.top == coords.top
+@test size(l1) == size(l2)
+@test l1.grid == l2.grid
 
-@test stride(layer) == stride(temp)
-@test longitudes(layer)[1] == -144.91666666666666
-@test longitudes(layer)[end] == -50.083333333333336
-@test latitudes(layer)[1] == 20.083333333333332
-@test latitudes(layer)[end] == 74.91666666666667
+for l in (l1, l2)
+    @test size(l) == (330, 570)
+
+    @test l.left == coords.left
+    @test l.right == coords.right
+    @test l.bottom == coords.bottom
+    @test l.top == coords.top
+
+    @test stride(l) == stride(temp)
+    @test longitudes(l)[1] == -144.91666666666666
+    @test longitudes(l)[end] == -50.083333333333336
+    @test latitudes(l)[1] == 20.083333333333332
+    @test latitudes(l)[end] == 74.91666666666667
+end
 
 end

--- a/test/subsetting.jl
+++ b/test/subsetting.jl
@@ -1,0 +1,12 @@
+module SSLTestSubsetting
+using SimpleSDMLayers
+using Test
+
+temp = SimpleSDMPredictor(WorldClim, BioClim, 1)
+@test size(temp) == (1080, 2160)
+
+coords = (left = -145.0, right = -50.0, bottom = 20.0, top = 75.0)
+layer = temp[coords]
+@test size(layer) == (330, 570)
+
+end

--- a/test/subsetting.jl
+++ b/test/subsetting.jl
@@ -8,11 +8,16 @@ temp = SimpleSDMPredictor(WorldClim, BioClim, 1)
 coords = (left = -145.0, right = -50.0, bottom = 20.0, top = 75.0)
 l1 = temp[coords]
 l2 = SimpleSDMPredictor(WorldClim, BioClim, 1; coords...)
+tempfile = tempname()
+geotiff(tempfile, l2)
+l3 = replace(geotiff(SimpleSDMPredictor, tempfile), NaN => nothing)
 
 @test size(l1) == size(l2)
+@test size(l1) == size(l3)
 @test l1.grid == l2.grid
+@test l1.grid == l3.grid
 
-for l in (l1, l2)
+for l in (l1, l2, l3)
     @test size(l) == (330, 570)
 
     @test l.left == coords.left


### PR DESCRIPTION
**What the pull request does**   

:boom: Breaking changes!
:bug: But it's actually just solving bugs and unexpected behaviours, some of which have been around since v0.4.3. The calls should work as before but will return different results in important functions.

Fixes #99, fixes #100, fixes #102, fixes #103, fixes #104.

**Checklist**

Using:
- `layer = SimpleSDMPredictor(WorldClim, BioClim, 1)`
- `coords = (left = -145.0, right = -50.0, bottom = 20.0, top = 75.0)`

This PR needs to fix:
- [x] `getindex(layer; coords)` should return a layer with dimensions 330 x 570
- [x] `getindex(layer; coords)` should return a layer whose bounding coordinates are **exactly** (20.083333333333332, 74.91666666666667) for latitude and (-144.91666666666666, -50.083333333333336) for longitude (same as 10 arc-min WorldClim raster cropped in QGIS/GDAL)
- [x] `getindex(layer; coords)` should return a layer whose stride is **exactly** (0.08333333333333333, 0.08333333333333333)
- [x] `geotiff(layer; coords...)` should return the same thing
- [x]  `geotiff("test.tif", layer)` and `geotiff(SimpleSDMPredictor, "test.tif")` should allow to write and re-read the same layer
- [x] All these changes should have appropriate tests

See my [before/after comment](https://github.com/EcoJulia/SimpleSDMLayers.jl/pull/101#issuecomment-853162099) for the details.

**Type of change**   

Please indicate the relevant option(s)

- [x] :bug: Bug fix (non-breaking change which fixes an issue)
- [ ] :sparkle: New feature (non-breaking change which adds functionality)
- [x] :boom: Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] :book: This change requires a documentation update

**Checklist**

- [x] The changes are documented
  - [x] The docstrings of the different functions describe the arguments, purpose, and behavior 
  - [x] There are examples in the documentation website
- [x] The changes are tested
- [x] The changes **do not** modify the behavior of the previously existing functions
  - If they **do**, please explain why and how in the introduction paragraph
- [x] For **new contributors** - my name and information are added to `.zenodo.json`
- [x] The `Project.toml` field `version` has been updated
  - Change the *last* number for a `v0.0.x` series release, a bug fix, or a performance improvement
  - Change the *middle* number for additional features that *do not* break the current test suite (unless you fix a bug in the test suite)
  - Change the *first* number for changes that break the current test suite
