### PR TITLE
Use missing instead of nothing in `DataFrame()` overload

### DIFF
--- a/docs/src/examples/dataframes.md
+++ b/docs/src/examples/dataframes.md
@@ -29,7 +29,7 @@ using Statistics
 using DataFrames
 
 # Load environmental data
-temperature, precipitation = worldclim([1,12])
+temperature, precipitation = SimpleSDMPredictor(WorldClim, BioClim, [1,12])
 
 # Get GBIF occurrences
 kingfisher = GBIF.taxon("Megaceryle alcyon", strict=true)
@@ -59,11 +59,12 @@ rename!(env_df, :x1 => :temperature, :x2 => :precipitation)
 first(env_df, 5)
 ```
 
-Note that the resulting `DataFrame` will include the values set to `nothing` in
-the layers. We might want to remove those rows using `filter!`:
+Note that the resulting `DataFrame` will include `missing` values for the 
+elements set to `nothing` in the layers. We might want to remove those rows 
+using `filter!` or `dropmissing!`:
 
 ```@example dataframes
-filter!(x -> !isnothing(x.temperature) && !isnothing(x.precipitation), env_df);
+dropmissing!(env_df, [:temperature, :precipitation]);
 last(env_df, 5)
 ```
 

--- a/src/SimpleSDMLayers.jl
+++ b/src/SimpleSDMLayers.jl
@@ -72,11 +72,11 @@ export clip
 function __init__()
     @require GBIF="ee291a33-5a6c-5552-a3c8-0f29a1181037" begin
         @info "GBIF integration loaded"
-        include(joinpath(dirname(pathof(SimpleSDMLayers)), "integrations", "GBIF.jl"))
+        include("integrations/GBIF.jl")
     end
     @require DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0" begin
         @info "DataFrames integration loaded"
-        include(joinpath(dirname(pathof(SimpleSDMLayers)), "integrations", "DataFrames.jl"))
+        include("integrations/DataFrames.jl")
     end
 
 end

--- a/src/integrations/DataFrames.jl
+++ b/src/integrations/DataFrames.jl
@@ -79,7 +79,8 @@ function DataFrames.DataFrame(layers::Array{T}; kw...) where {T <: SimpleSDMLaye
     
     lats = repeat(latitudes(l1), outer = size(l1, 2))
     lons = repeat(longitudes(l1), inner = size(l1, 1))
-    values = mapreduce(x -> replace(vec(x.grid), nothing => missing), hcat, layers)
+    values = mapreduce(x -> vec(x.grid), hcat, layers)
+    values = replace(values, nothing => missing)
     
     df = DataFrames.DataFrame(values, :auto; kw...)
     DataFrames.insertcols!(df, 1, :longitude => lons)

--- a/src/integrations/DataFrames.jl
+++ b/src/integrations/DataFrames.jl
@@ -61,7 +61,7 @@ function DataFrames.DataFrame(layer::T; kw...) where {T <: SimpleSDMLayer}
     lats = repeat(latitudes(layer), outer = size(layer, 2))
     lons = repeat(longitudes(layer), inner = size(layer, 1))
     values = replace(vec(layer.grid), nothing => missing)
-    df = DataFrames.DataFrame(latitude = lats, longitude = lons, values = values; kw...)
+    df = DataFrames.DataFrame(longitude = lons, latitude = lats, values = values; kw...)
     return df
 end
 
@@ -82,8 +82,8 @@ function DataFrames.DataFrame(layers::Array{T}; kw...) where {T <: SimpleSDMLaye
     values = mapreduce(x -> replace(vec(x.grid), nothing => missing), hcat, layers)
     
     df = DataFrames.DataFrame(values, :auto; kw...)
-    DataFrames.insertcols!(df, 1, :latitude => lats)
     DataFrames.insertcols!(df, 1, :longitude => lons)
+    DataFrames.insertcols!(df, 2, :latitude => lats)
     return df
 end
 

--- a/test/dataframes.jl
+++ b/test/dataframes.jl
@@ -5,7 +5,7 @@ using Test
 
 temperature = SimpleSDMPredictor(WorldClim, BioClim, 1)
 
-df = DataFrame(latitude = [0.0, 1.0], longitude = [30.0, 31.0], values = [42.0, 15.0])
+df = DataFrame(longitude = [30.0, 31.0], latitude = [0.0, 1.0], values = [42.0, 15.0])
 
 @test eltype(temperature[df]) <: Number
 
@@ -13,13 +13,24 @@ temperature_clip = clip(temperature, df)
 
 @test typeof(temperature_clip) == typeof(temperature)
 
-@test typeof(DataFrame(temperature_clip)) == DataFrame
-@test eltype(DataFrame(temperature_clip).values) == Union{Missing, eltype(temperature_clip)}
-@test typeof(DataFrame([temperature_clip, temperature_clip])) == DataFrame
-@test eltype(DataFrame([temperature_clip, temperature_clip]).x1) == Union{Missing, eltype(temperature_clip)}
+df1 = DataFrame(temperature_clip)
+df2 = DataFrame([temperature_clip, temperature_clip])
+
+@test typeof(df1) == DataFrame
+@test eltype(df1.values) == Union{Missing, eltype(temperature_clip)}
+@test typeof(df2) == DataFrame
+@test eltype(df2.x1) == Union{Missing, eltype(temperature_clip)}
 
 @test typeof(SimpleSDMPredictor(df, :values, temperature_clip)) <: SimpleSDMLayer
 @test typeof(SimpleSDMPredictor(df, :values, temperature_clip)) <: SimpleSDMPredictor
+
+l1 = SimpleSDMPredictor(df1, :values, temperature_clip)
+l2 = SimpleSDMPredictor(df2, :x2, temperature_clip)
+for l in (l1, l2)
+    @test isequal(l.grid, temperature_clip.grid)
+    @test isequal(longitudes(l), longitudes(temperature_clip))
+    @test isequal(latitudes(l), latitudes(temperature_clip))
+end
 
 mbool = mask(temperature_clip, df, Bool)
 @test eltype(mbool) == Bool

--- a/test/dataframes.jl
+++ b/test/dataframes.jl
@@ -14,9 +14,9 @@ temperature_clip = clip(temperature, df)
 @test typeof(temperature_clip) == typeof(temperature)
 
 @test typeof(DataFrame(temperature_clip)) == DataFrame
-@test eltype(DataFrame(temperature_clip).values) == eltype(temperature_clip.grid)
+@test eltype(DataFrame(temperature_clip).values) == Union{Missing, eltype(temperature_clip)}
 @test typeof(DataFrame([temperature_clip, temperature_clip])) == DataFrame
-@test eltype(DataFrame([temperature_clip, temperature_clip]).x1) == eltype(temperature_clip.grid)
+@test eltype(DataFrame([temperature_clip, temperature_clip]).x1) == Union{Missing, eltype(temperature_clip)}
 
 @test typeof(SimpleSDMPredictor(df, :values, temperature_clip)) <: SimpleSDMLayer
 @test typeof(SimpleSDMPredictor(df, :values, temperature_clip)) <: SimpleSDMPredictor


### PR DESCRIPTION
**What the pull request does**   

As mentioned in #52, this replaces `nothing` elements by `missing` when converting a layer to a DataFrame, as `missing` has better support.

**Type of change**   

Please indicate the relevant option(s)

- [ ] :bug: Bug fix (non-breaking change which fixes an issue)
- [ ] :sparkle: New feature (non-breaking change which adds functionality)
- [x] :boom: Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] :book: This change requires a documentation update

**Checklist**

- [x] The changes are documented
  - [x] The docstrings of the different functions describe the arguments, purpose, and behavior 
  - [ ] There are examples in the documentation website
- [x] The changes are tested
- [x] The changes **do not** modify the behavior of the previously existing functions
  - If they **do**, please explain why and how in the introduction paragraph
- [x] For **new contributors** - my name and information are added to `.zenodo.json`
- [x] The `Project.toml` field `version` has been updated
  - Change the *last* number for a `v0.0.x` series release, a bug fix, or a performance improvement
  - Change the *middle* number for additional features that *do not* break the current test suite (unless you fix a bug in the test suite)
  - Change the *first* number for changes that break the current test suite
