### PR TITLE
Fix the BRT vignette

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SimpleSDMLayers"
 uuid = "2c645270-77db-11e9-22c3-0f302a89c64c"
 authors = ["Timothée Poisot <timothee.poisot@umontreal.ca>", "Gabriel Dansereau <gabriel.dansereau@umontreal.ca>"]
-version = "0.8.0"
+version = "0.8.1"
 
 [deps]
 ArchGDAL = "c9ce4bd3-c3d5-55b8-8973-c0e20141b8c3"

--- a/Project.toml
+++ b/Project.toml
@@ -19,8 +19,8 @@ ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
 
 [compat]
 ArchGDAL = "0.7"
-Colors = "0.12"
 ColorBlendModes = "0.2"
+Colors = "0.12"
 Distances = "0.10"
 Downloads = "1.4"
 GeometryBasics = "0.4"

--- a/docs/src/sdm/brt.jl
+++ b/docs/src/sdm/brt.jl
@@ -166,19 +166,19 @@ tn = zeros(Float64, length(cutoff));
 fn = zeros(Float64, length(cutoff));
 
 for (i, c) in enumerate(cutoff)
-    pred = distribution[xy] .>= c
-    tp[i] = sum(pred .& obs)
-    tn[i] = sum(.!(pred) .& (.!obs))
-    fp[i] = sum(pred .& (.!obs))
-    fn[i] = sum(.!(pred) .& obs)
+    prd = distribution[xy] .>= c
+    tp[i] = sum(prd .& obs)
+    tn[i] = sum(.!(prd) .& (.!obs))
+    fp[i] = sum(prd .& (.!obs))
+    fn[i] = sum(.!(prd) .& obs)
 end
 
 # From this, we can calculate a number of validation measures:
 
-tpr = tp ./ (tp .+ fn)
-fpr = fp ./ (fp .+ tn)
-J = (tp ./ (tp .+ fn)) + (tn ./ (tn .+ fp)) .- 1.0
-ppv = tp ./ (tp .+ fp)
+tpr = tp ./ (tp .+ fn);
+fpr = fp ./ (fp .+ tn);
+J = (tp ./ (tp .+ fn)) + (tn ./ (tn .+ fp)) .- 1.0;
+ppv = tp ./ (tp .+ fp);
 
 # The ROC-AUC is an overall measure of how good the fit is:
 

--- a/docs/src/sdm/brt.jl
+++ b/docs/src/sdm/brt.jl
@@ -161,16 +161,18 @@ J = similar(cutoff);
 # The loop to measure everything is fairly simple, as we already know the
 # correct positions of presences and absences:
 
-for (i, c) in enumerate(cutoff)
-    p_presence = distribution[xy_presence] .>= c
-    p_absence = distribution[xy_absence] .>= c
-    tp = sum(p_presence)
-    fp = length(p_presence) - tp
-    fn = sum(p_absence)
-    tn = length(p_absence) - fn
-    J[i] = tp / (tp + fn) + tn / (tn + fp) - 1
-end
+obs = y .> 0
 
+for (i, c) in enumerate(cutoff)
+    predic = distribution[xy] .>= c
+    tp = sum(obs .& predic)
+	tn = sum(.!obs .& (.!predic))
+    fp = sum(.!obs .& predic)
+    fn = sum(obs .& (.!predic))
+    J[i] = tp / (tp + fn) + tn / (tn + fp) - 1
+	FPR[i] = fp/(fp+tn)
+	TPR[i] = tp/(tp+fn)
+end
 # We can finally replace the `NaN` values by the random estimate, and look at
 # the plot:
 


### PR DESCRIPTION
**What the pull request does**   

The calculation of the adjacency matrix in the BRT vignette was wrong, in a way that gave the right  result, but it was still wrong, which is generally regarded as "oof". The PR fixes this.

**Type of change**   

- [x] :bug: Bug fix (non-breaking change which fixes an issue)
- [x] :book: This change requires a documentation update

**Checklist**

- [x] The `Project.toml` field `version` has been updated to `v0.8.1`
